### PR TITLE
components: added HBase

### DIFF
--- a/tdp/components/hbase.yml
+++ b/tdp/components/hbase.yml
@@ -43,7 +43,6 @@
 
 - name: hbase_regionserver_start
   depends_on:
-    - zookeeper_server_init
     - hbase_master_start
     - hbase_regionserver_install
 


### PR DESCRIPTION
Fixes #5 

I did not implement `hbase_master_iniŧ` and `hbase_regionserver_init` because they do not exist as [playbooks](https://github.com/TOSIT-FR/ansible-tdp-roles/tree/master/playbooks) but we already have `hdfs_datanode_init` defined previously which is also not a playbook.

We should pick a pattern now to avoid wasting time later:
- Define these in `components.yml` even if they do not exist in playbooks / do nothing
- Do not define these in `components.yml` in this case

I prefer the 2nd option for simplicity.

What do you think @RReivax @rpignolet ?