### PR TITLE
core: add topology class to retrieve hosts and groups

### DIFF
--- a/tdp/core/topology.py
+++ b/tdp/core/topology.py
@@ -1,6 +1,5 @@
 import logging
 import ansible.constants as C
-from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.parsing.dataloader import DataLoader
 from ansible.inventory.manager import InventoryManager
 from ansible.vars.manager import VariableManager
@@ -8,7 +7,7 @@ from ansible.vars.manager import VariableManager
 logger = logging.getLogger("tdp").getChild("topology")
 
 
-class Topology:
+class AnsibleTopologyReader:
     def __init__(self, hosts_files=None):
         self._hosts_files = hosts_files
         self._loader = DataLoader()


### PR DESCRIPTION
The whitelist is there to prevent tdp-lib from handling groups in the inventory that are not related to the distribution. For example, someone can have a `database` or `ldap` group, or any other product they install on the side. It doesn't concern TDP. 