### PR TITLE
devtools: add the possibility to give multi nodes for graph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ To run `dag` you can either use `poetry run dag` or `dag` if you are inside the 
 
 Dag usage:
 ```
-usage: dag [-h] [node]
+usage: dag [-h] [nodes [nodes ...]]
 
-Compute and display a graph. Add a node name to get a subgraph to the node.
+Compute and display a graph. Add node names to get a subgraph to the nodes.
 
 positional arguments:
-  node        Node on which to produce ancestors graph
+  nodes       Nodes on which to produce ancestors graph
 
 optional arguments:
   -h, --help  show this help message and exit

--- a/tdp/devtools/dag_debug.py
+++ b/tdp/devtools/dag_debug.py
@@ -14,7 +14,7 @@ except ImportError as e:
 
 
 DAG_SUMMARY = (
-    "Compute and display a graph. Add a node name to get a subgraph to the node."
+    "Compute and display a graph. Add node names to get a subgraph to the nodes."
 )
 
 
@@ -22,31 +22,31 @@ def debug_dag_args():
     parser = argparse.ArgumentParser(description=DAG_SUMMARY)
     parser.description
     parser.add_argument(
-        "node",
-        type=str,
-        nargs="?",
+        "nodes",
+        nargs="*",
         default=None,
-        help="Node on which to produce ancestors graph",
+        help="Nodes on which to produce ancestors graph",
     )
     return parser
 
 
-def debug_dag(node=None):
+def debug_dag(nodes=None):
     f"""{DAG_SUMMARY}
 
     This function will lookup in the program arguments to check wether there's a node if no node is specified.
     Args:
-        node (str, optional): Node on which to compute a graph. Defaults to None.
+        nodes (List[str], optional): Nodes on which to compute a graph. Defaults to None.
     """
-    if not node:
-        node = debug_dag_args().parse_args().node
+    if not nodes:
+        nodes = debug_dag_args().parse_args().nodes
 
     dag = Dag()
     graph = dag.graph
-    if node:
-        ancestors = nx.ancestors(graph, node)
+    if nodes:
         # Nx ancestors only returns the ancestor, and node the selected node
-        # Add it to simplify visualization
-        ancestors.add(node)
+        # Add them to simplify visualization
+        ancestors = set(nodes)
+        for node in nodes:
+            ancestors.update(nx.ancestors(graph, node))
         graph = graph.subgraph(ancestors)
     show(graph)


### PR DESCRIPTION
In this PR, we add the possibility to provide more than one node to generate a graph.

A good example of this use case is wanting to generate the dag for the actions `hdfs_init` and `yarn_init` at the same time


New usage:
```
usage: dag [-h] [nodes [nodes ...]]

Compute and display a graph. Add node names to get a subgraph to the node.

positional arguments:
  nodes       Nodes on which to produce ancestors graph

optional arguments:
  -h, --help  show this help message and exit
```
