### PR TITLE
Add conf nodes to the DAG

### DIFF
--- a/tdp/components/hadoop.yml
+++ b/tdp/components/hadoop.yml
@@ -2,6 +2,10 @@
 - name: hadoop_client_install
   depends_on: []
 
+- name: hadoop_client_config
+  depends_on:
+    - hadoop_client_install
+
 - name: hadoop_install
   depends_on: []
 

--- a/tdp/components/hbase.yml
+++ b/tdp/components/hbase.yml
@@ -31,6 +31,34 @@
   depends_on:
     - hadoop_client_install
 
+- name: hbase_client_config
+  depends_on:
+    - hbase_client_install
+
+- name: hbase_master_config
+  depends_on:
+    - hbase_master_install
+
+- name: hbase_regionserver_config
+  depends_on:
+    - hbase_regionserver_install
+
+- name: hbase_rest_config
+  depends_on:
+    - hbase_rest_install
+
+- name: phoenix_client_config
+  depends_on:
+    - phoenix_client_install
+
+- name: phoenix_queryserver_client_config
+  depends_on:
+    - phoenix_queryserver_client_install
+
+- name: phoenix_queryserver_daemon_config
+  depends_on:
+    - phoenix_queryserver_daemon_install
+
 - name: hbase_hdfs_init
   depends_on:
     - hdfs_init
@@ -39,15 +67,16 @@
   depends_on:
     - zookeeper_server_init
     - hbase_hdfs_init
-    - hbase_master_install
+    - hbase_master_config
 
 - name: hbase_regionserver_start
   depends_on:
+    - hbase_regionserver_config
     - hbase_master_start
-    - hbase_regionserver_install
 
 - name: hbase_rest_start
   depends_on:
+    - hbase_rest_config
     - hbase_master_start
     - hbase_regionserver_start
 
@@ -57,5 +86,5 @@
 
 - name: phoenix_queryserver_daemon_start
   depends_on:
+    - phoenix_queryserver_daemon_config
     - hbase_init
-    - phoenix_queryserver_daemon_install

--- a/tdp/components/hdfs.yml
+++ b/tdp/components/hdfs.yml
@@ -12,10 +12,22 @@
   depends_on:
     - hadoop_install
 
+- name: hdfs_namenode_config
+  depends_on:
+    - hdfs_namenode_install
+
+- name: hdfs_datanode_config
+  depends_on:
+    - hdfs_datanode_install
+
+- name: hdfs_journalnode_config
+  depends_on:
+    - hdfs_journalnode_install
+
 - name: hdfs_namenode_formatzk
   depends_on:
     - zookeeper_server_init
-    - hdfs_namenode_install
+    - hdfs_namenode_config
 
 - name: hdfs_namenode_start
   depends_on:
@@ -27,7 +39,7 @@
 
 - name: hdfs_datanode_start
   depends_on:
-    - hdfs_datanode_install
+    - hdfs_datanode_config
     - hdfs_namenode_init
 
 - name: hdfs_datanode_init
@@ -36,7 +48,7 @@
 
 - name: hdfs_journalnode_start
   depends_on:
-    - hdfs_journalnode_install
+    - hdfs_journalnode_config
     - hdfs_namenode_formatzk
 
 - name: hdfs_journalnode_init
@@ -48,6 +60,12 @@
     - hdfs_namenode_install
     - hdfs_datanode_install
     - hdfs_journalnode_install
+
+- name: hdfs_config
+  depends_on:
+    - hdfs_namenode_config
+    - hdfs_datanode_config
+    - hdfs_journalnode_config
 
 - name: hdfs_start
   depends_on:

--- a/tdp/components/hive.yml
+++ b/tdp/components/hive.yml
@@ -15,10 +15,23 @@
   depends_on:
     - hive_hiveserver2_install
 
+- name: hive_client_config
+  depends_on:
+    - hive_client_install
+
+- name: hive_hiveserver2_config
+  depends_on:
+    - hive_kerberos_install
+
+- name: hive_tez_config
+  depends_on:
+    - hive_tez_install
+
 - name: hive_hiveserver2_start
   depends_on:
     - zookeeper_server_init
-    - hive_kerberos_install
+    - hive_hiveserver2_config
+    - hive_tez_config
     - hive_hdfs_init
 
 - name: hive_hdfs_init
@@ -30,6 +43,12 @@
     - hive_client_install
     - hive_tez_install
     - hive_kerberos_install
+
+- name: hive_config
+  depends_on:
+    - hive_client_config
+    - hive_hiveserver2_config
+    - hive_tez_config
 
 - name: hive_start
   depends_on:

--- a/tdp/components/ranger.yml
+++ b/tdp/components/ranger.yml
@@ -3,9 +3,13 @@
   depends_on:
     - hadoop_client_install
 
-- name: ranger_admin_start
+- name: ranger_admin_config
   depends_on:
     - ranger_admin_install
+
+- name: ranger_admin_start
+  depends_on:
+    - ranger_admin_config
     - hdfs_init
 
 - name: ranger_admin_init

--- a/tdp/components/spark.yml
+++ b/tdp/components/spark.yml
@@ -13,14 +13,22 @@
   depends_on:
     - spark_historyserver_install
 
+- name: spark_client_config
+  depends_on:
+    - spark_client_install
+
+- name: spark_historyserver_config
+  depends_on:
+    - spark_kerberos_install
+    - spark_ssl-tls_install
+
 - name: spark_hdfs_init
   depends_on:
     - hdfs_init
 
 - name: spark_historyserver_start
   depends_on:
-    - spark_kerberos_install
-    - spark_ssl-tls_install
+    - spark_historyserver_config
     - spark_hdfs_init
 
 - name: spark_install
@@ -28,6 +36,11 @@
     - spark_client_install
     - spark_kerberos_install
     - spark_ssl-tls_install
+
+- name: spark_config
+  depends_on:
+    - spark_client_config
+    - spark_historyserver_config
 
 - name: spark_start
   depends_on:

--- a/tdp/components/yarn.yml
+++ b/tdp/components/yarn.yml
@@ -11,9 +11,21 @@
   depends_on:
     - hadoop_install
 
-- name: yarn_resourcemanager_start
+- name: yarn_nodemanager_config
+  depends_on:
+    - yarn_nodemanager_install
+
+- name: yarn_resourcemanager_config
   depends_on:
     - yarn_resourcemanager_install
+
+- name: yarn_apptimelineserver_config
+  depends_on:
+    - yarn_apptimelineserver_install
+
+- name: yarn_resourcemanager_start
+  depends_on:
+    - yarn_resourcemanager_config
     - yarn_apptimelineserver_init
 
 - name: yarn_resourcemanager_init
@@ -26,7 +38,7 @@
 
 - name: yarn_nodemanager_start
   depends_on:
-    - yarn_nodemanager_install
+    - yarn_nodemanager_config
     - yarn_resourcemanager_init
 
 - name: yarn_nodemanager_init
@@ -35,7 +47,7 @@
 
 - name: yarn_apptimelineserver_start
   depends_on:
-    - yarn_apptimelineserver_install
+    - yarn_apptimelineserver_config
 
 - name: yarn_apptimelineserver_init
   depends_on:
@@ -46,6 +58,12 @@
     - yarn_resourcemanager_install
     - yarn_nodemanager_install
     - yarn_apptimelineserver_install
+
+- name: yarn_config
+  depends_on:
+    - yarn_resourcemanager_config
+    - yarn_nodemanager_config
+    - yarn_apptimelineserver_config
 
 - name: yarn_start
   depends_on:

--- a/tdp/components/zookeeper.yml
+++ b/tdp/components/zookeeper.yml
@@ -2,9 +2,13 @@
 - name: zookeeper_server_install
   depends_on: []
 
-- name: zookeeper_server_start
+- name: zookeeper_server_config
   depends_on:
     - zookeeper_server_install
+
+- name: zookeeper_server_start
+  depends_on:
+    - zookeeper_server_config
 
 - name: zookeeper_server_init
   depends_on:


### PR DESCRIPTION
Fix #25 

Format/style change:

- move `hdfs_namenode_start` after `hdfs_namenode_formatzk`
- move `yarn_init` after `yarn_start`
- move `hive_tez_install` after `hive_hiveserver2_install`

Behavior change:

- add missing `yarn_apptimelineserver_*` for yarn service
- add `*_config` for existing components