### PR TITLE
core: enable keyboard interrupt handling

### DIFF
--- a/tdp/core/runner/action_runner.py
+++ b/tdp/core/runner/action_runner.py
@@ -73,7 +73,7 @@ class ActionRunner:
         end = datetime.now()
 
         filtered_failures = filter(
-            lambda action_log: action_log.state == StateEnum.FAILURE, action_logs
+            lambda action_log: action_log.state == StateEnum.FAILURE.value, action_logs
         )
 
         state = StateEnum.FAILURE if any(filtered_failures) else StateEnum.SUCCESS

--- a/tdp/core/runner/ansible_executor.py
+++ b/tdp/core/runner/ansible_executor.py
@@ -15,24 +15,30 @@ class AnsibleExecutor(Executor):
         self._rundir = run_directory
         self._dry = dry
 
+    def _execute_ansible_command(self, command):
+        with io.BytesIO() as byte_stream:
+            try:
+                res = subprocess.Popen(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    cwd=self._rundir,
+                    universal_newlines=True,
+                )
+                for stdout_line in iter(res.stdout.readline, ""):
+                    print(stdout_line)
+                    byte_stream.write(bytes(stdout_line, "utf-8"))
+                state = StateEnum.SUCCESS if res.poll() == 0 else StateEnum.FAILURE
+            except KeyboardInterrupt:
+                logger.debug("KeyboardInterrupt caught")
+                byte_stream.write(b"\nKeyboardInterrupt")
+                return StateEnum.FAILURE, byte_stream.getvalue()
+            return state, byte_stream.getvalue()
+
     def execute(self, action):
         playbook_action = os.path.join(self._playdir, action + ".yml")
         command = ["ansible-playbook", playbook_action]
         if self._dry:
             logger.info("[DRY MODE] Ansible command: " + " ".join(command))
             return StateEnum.SUCCESS, b""
-
-        res = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            cwd=self._rundir,
-            universal_newlines=True,
-        )
-        with io.BytesIO() as byte_stream:
-            for stdout_line in iter(res.stdout.readline, ""):
-                print(stdout_line)
-                byte_stream.write(bytes(stdout_line, "utf-8"))
-            logs = byte_stream.getvalue()
-        state = StateEnum.SUCCESS if res.poll() == 0 else StateEnum.FAILURE
-        return state, logs
+        return self._execute_ansible_command(command)


### PR DESCRIPTION
fix #45 

In the future, we might want to make an `ActionRun` <<interruptable>>, but it is outside #45 scope