### PR TITLE
components: add "(hdfs|yarn)_client_(config|init)"

### DIFF
--- a/tdp/components/hbase.yml
+++ b/tdp/components/hbase.yml
@@ -54,40 +54,54 @@
 
 - name: hbase_client_config
   depends_on:
+    - hdfs_client_config
+    - yarn_client_config
     - hbase_kerberos_install
 
 - name: hbase_master_config
   depends_on:
+    - hdfs_client_config
+    - yarn_client_config
     - hbase_kerberos_install
     - hbase_ssl-tls_install
 
 - name: hbase_regionserver_config
   depends_on:
+    - hdfs_client_config
+    - yarn_client_config
     - hbase_kerberos_install
     - hbase_ssl-tls_install
 
 - name: hbase_rest_config
   depends_on:
+    - hdfs_client_config
+    - yarn_client_config
     - hbase_kerberos_install
     - hbase_ssl-tls_install
 
 - name: hbase_phoenix_client_config
   noop: yes
   depends_on:
+    - hdfs_client_config
+    - yarn_client_config
     - hbase_phoenix_client_install
 
 - name: hbase_phoenix_queryserver_client_config
   depends_on:
+    - hdfs_client_config
+    - yarn_client_config
     - hbase_phoenix_queryserver_client_install
 
 - name: hbase_phoenix_queryserver_daemon_config
   depends_on:
+    - hdfs_client_config
+    - yarn_client_config
     - hbase_phoenix_kerberos_install
     - hbase_phoenix_ssl-tls_install
 
 - name: hbase_hdfs_init
   depends_on:
-    - hdfs_init
+    - hdfs_client_init
 
 - name: hbase_master_start
   depends_on:
@@ -109,7 +123,6 @@
 - name: hbase_phoenix_queryserver_daemon_start
   depends_on:
     - hbase_phoenix_queryserver_daemon_config
-    - hbase_hdfs_init
     - hbase_master_start
     - hbase_regionserver_start
     - hbase_rest_start

--- a/tdp/components/hdfs.yml
+++ b/tdp/components/hdfs.yml
@@ -41,6 +41,14 @@
     - hdfs_kerberos_install
     - hdfs_ssl-tls_install
 
+- name: hdfs_client_config
+  noop: yes
+  depends_on:
+    - hadoop_client_config
+    - hdfs_namenode_config
+    - hdfs_datanode_config
+    - hdfs_journalnode_config
+
 - name: hdfs_namenode_formatzk
   depends_on:
     - zookeeper_server_init
@@ -75,6 +83,14 @@
   depends_on:
     - hdfs_journalnode_start
 
+- name: hdfs_client_init
+  noop: yes
+  depends_on:
+    - hdfs_client_config
+    - hdfs_namenode_init
+    - hdfs_journalnode_init
+    - hdfs_datanode_init
+
 - name: hdfs_install
   noop: yes
   depends_on:
@@ -104,3 +120,4 @@
     - hdfs_namenode_init
     - hdfs_journalnode_init
     - hdfs_datanode_init
+    - hdfs_client_init

--- a/tdp/components/hive.yml
+++ b/tdp/components/hive.yml
@@ -23,6 +23,8 @@
 
 - name: hive_client_config
   depends_on:
+    - hdfs_client_config
+    - yarn_client_config
     - hive_kerberos_install
     - hive_ssl-tls_install
 
@@ -38,13 +40,27 @@
 - name: hive_hiveserver2_start
   depends_on:
     - zookeeper_server_init
+    - hdfs_client_config
+    - yarn_client_config
     - hive_hiveserver2_config
     - hive_tez_config
+
+- name: hive_client_init
+  noop: yes
+  depends_on:
+    - hdfs_client_init
+    - yarn_client_init
+
+- name: hive_hiveserver2_init
+  noop: yes
+  depends_on:
+    - yarn_client_init
+    - hive_hiveserver2_start
     - hive_hdfs_init
 
 - name: hive_hdfs_init
   depends_on:
-    - hdfs_init
+    - hdfs_client_init
 
 - name: hive_install
   noop: yes
@@ -70,5 +86,6 @@
 - name: hive_init
   noop: yes
   depends_on:
+    - hive_client_init
+    - hive_hiveserver2_init
     - hive_hdfs_init
-    - hive_hiveserver2_start

--- a/tdp/components/spark.yml
+++ b/tdp/components/spark.yml
@@ -25,12 +25,18 @@
 
 - name: spark_hdfs_init
   depends_on:
-    - hdfs_init
+    - hdfs_client_init
 
 - name: spark_historyserver_start
   depends_on:
+    - yarn_client_config
     - spark_historyserver_config
     - spark_hdfs_init
+
+- name: spark_historyserver_init
+  noop: yes
+  depends_on:
+    - yarn_client_init
 
 - name: spark_install
   noop: yes
@@ -55,4 +61,4 @@
   noop: yes
   depends_on:
     - spark_hdfs_init
-    - spark_historyserver_start
+    - spark_historyserver_init

--- a/tdp/components/yarn.yml
+++ b/tdp/components/yarn.yml
@@ -40,15 +40,19 @@
     - yarn_kerberos_install
     - yarn_ssl-tls_install
 
-- name: yarn_resourcemanager_start
-  depends_on:
-    - yarn_resourcemanager_config
-    - yarn_apptimelineserver_init
-
-- name: yarn_resourcemanager_init
+- name: yarn_client_config
   noop: yes
   depends_on:
-    - yarn_resourcemanager_start
+    - hadoop_client_config
+    - yarn_nodemanager_config
+    - yarn_resourcemanager_config
+    - yarn_apptimelineserver_config
+
+- name: yarn_resourcemanager_start
+  depends_on:
+    - hdfs_client_init
+    - yarn_resourcemanager_config
+    - yarn_apptimelineserver_start
 
 - name: yarn_resourcemanager_capacityscheduler
   depends_on:
@@ -57,20 +61,19 @@
 - name: yarn_nodemanager_start
   depends_on:
     - yarn_nodemanager_config
-    - yarn_resourcemanager_init
-
-- name: yarn_nodemanager_init
-  noop: yes
-  depends_on:
-    - yarn_nodemanager_start
+    - yarn_resourcemanager_start
 
 - name: yarn_apptimelineserver_start
   depends_on:
+    - hdfs_client_init
     - yarn_apptimelineserver_config
 
-- name: yarn_apptimelineserver_init
+- name: yarn_client_init
   noop: yes
   depends_on:
+    - yarn_client_config
+    - yarn_resourcemanager_start
+    - yarn_nodemanager_start
     - yarn_apptimelineserver_start
 
 - name: yarn_install
@@ -99,6 +102,7 @@
 - name: yarn_init
   noop: yes
   depends_on:
-    - yarn_resourcemanager_init
-    - yarn_nodemanager_init
-    - yarn_apptimelineserver_init
+    - yarn_resourcemanager_start
+    - yarn_nodemanager_start
+    - yarn_apptimelineserver_start
+    - yarn_client_init


### PR DESCRIPTION
Fix #58.

When a component depends on HDFS or YARN, it must depends on `hdfs_client_init` or `yarn_client_init`. These 2 components depends on server init to ensure server is ready to handle request.