### PR TITLE
components: update zookeeper client with "zookeeper_config"

### DIFF
--- a/tdp/components/hadoop.yml
+++ b/tdp/components/hadoop.yml
@@ -4,6 +4,7 @@
 
 - name: hadoop_client_config
   depends_on:
+    - zookeeper_config
     - hadoop_client_install
 
 - name: hadoop_install

--- a/tdp/components/hbase.yml
+++ b/tdp/components/hbase.yml
@@ -60,6 +60,7 @@
 
 - name: hbase_master_config
   depends_on:
+    - zookeeper_config
     - hdfs_client_config
     - yarn_client_config
     - hbase_kerberos_install
@@ -105,7 +106,7 @@
 
 - name: hbase_master_start
   depends_on:
-    - zookeeper_server_init
+    - zookeeper_init
     - hbase_hdfs_init
     - hbase_master_config
 

--- a/tdp/components/hdfs.yml
+++ b/tdp/components/hdfs.yml
@@ -1,7 +1,6 @@
 ---
 - name: hdfs_namenode_install
   depends_on:
-    - zookeeper_server_install
     - hadoop_install
 
 - name: hdfs_datanode_install
@@ -32,6 +31,7 @@
 
 - name: hdfs_namenode_config
   depends_on:
+    - zookeeper_config
     - hdfs_kerberos_install
     - hdfs_ssl-tls_install
 
@@ -54,7 +54,7 @@
 
 - name: hdfs_namenode_formatzk
   depends_on:
-    - zookeeper_server_init
+    - zookeeper_init
     - hdfs_namenode_config
 
 - name: hdfs_namenode_start

--- a/tdp/components/hive.yml
+++ b/tdp/components/hive.yml
@@ -4,7 +4,6 @@
 
 - name: hive_hiveserver2_install
   depends_on:
-    - zookeeper_server_install
     - hadoop_install
 
 - name: hive_tez_install
@@ -30,6 +29,7 @@
 
 - name: hive_hiveserver2_config
   depends_on:
+    - zookeeper_config
     - hive_kerberos_install
     - hive_ssl-tls_install
 
@@ -39,7 +39,7 @@
 
 - name: hive_hiveserver2_start
   depends_on:
-    - zookeeper_server_init
+    - zookeeper_init
     - hdfs_client_config
     - yarn_client_config
     - hive_hiveserver2_config


### PR DESCRIPTION
Fix #71 

- Remove `zookeeper_server_install` not needed
- Use service actions instead of `zookeeper_server_*` actions