### PR TITLE
Remove "yarn_resourcemanager_capacityscheduler"

### DIFF
--- a/tdp/components/yarn.yml
+++ b/tdp/components/yarn.yml
@@ -66,10 +66,6 @@
     - yarn_resourcemanager_config
     - yarn_apptimelineserver_start
 
-- name: yarn_resourcemanager_capacityscheduler
-  depends_on:
-    - yarn_resourcemanager_start
-
 - name: yarn_nodemanager_start
   depends_on:
     - yarn_nodemanager_config


### PR DESCRIPTION
Fix #79 

`yarn_resourcemanager_capacityscheduler` is not used inside `tdp-collection` to deploy the cluster.