### PR TITLE
components: YARN components need "hdfs_client_config"

### DIFF
--- a/tdp/components/yarn.yml
+++ b/tdp/components/yarn.yml
@@ -35,16 +35,19 @@
 
 - name: yarn_nodemanager_config
   depends_on:
+    - hdfs_client_config
     - yarn_kerberos_install
     - yarn_ssl-tls_install
 
 - name: yarn_resourcemanager_config
   depends_on:
+    - hdfs_client_config
     - yarn_kerberos_install
     - yarn_ssl-tls_install
 
 - name: yarn_apptimelineserver_config
   depends_on:
+    - hdfs_client_config
     - yarn_kerberos_install
     - yarn_ssl-tls_install
 


### PR DESCRIPTION
Fix #85.

These YARN components need to copy `hdfs-site.xml`.