### PR TITLE
components: add "hadoop_client_config" for "hive_hiveserver2_config"

### DIFF
--- a/tdp/components/hive.yml
+++ b/tdp/components/hive.yml
@@ -30,6 +30,7 @@
 - name: hive_hiveserver2_config
   depends_on:
     - zookeeper_config
+    - hadoop_client_config
     - hive_kerberos_install
     - hive_ssl-tls_install
 


### PR DESCRIPTION
Fix #83 

`hive_hiveserver2_config` run `hadoop credential create` which needs `hadoop-env.sh`.