### PR TITLE
add "ranger_admin_config" dependency for "hdfs_ranger_config"

### DIFF
--- a/tdp/components/hdfs.yml
+++ b/tdp/components/hdfs.yml
@@ -51,6 +51,7 @@
 
 - name: hdfs_ranger_config
   depends_on:
+    - ranger_admin_config
     - hdfs_ranger_install
     - hdfs_namenode_config
 


### PR DESCRIPTION
Fix #88 

`hdfs_ranger_config` copy `hdfs-site.xml` inside Ranger Admin configuration directory but this directory is created by `ranger_admin_config`.