### PR TITLE
cli: fix deploy without node

### DIFF
--- a/tdp/cli/commands/deploy.py
+++ b/tdp/cli/commands/deploy.py
@@ -40,7 +40,7 @@ from tdp.cli.session import get_session_class
 @click.option("--dry", is_flag=True, help="Execute dag without running any action")
 @pass_dag
 def deploy(dag, target, sqlite_path, collection_path, run_directory, vars, filter, dry):
-    if target not in dag.components:
+    if target and target not in dag.components:
         raise ValueError(f"{target} is not a valid node")
     playbooks_directory = collection_path / "playbooks"
     run_directory = run_directory.absolute() if run_directory else None
@@ -56,7 +56,10 @@ def deploy(dag, target, sqlite_path, collection_path, run_directory, vars, filte
         check_services_cleanliness(service_managers)
 
         action_runner = ActionRunner(dag, ansible_executor, service_managers)
-        click.echo(f"Deploying {target}")
+        if target:
+            click.echo(f"Deploying {target}")
+        else:
+            click.echo(f"Deploying TDP")
         deployment = action_runner.run_to_node(target, filter)
         session.add(deployment)
         session.commit()


### PR DESCRIPTION
During CLI version to click, a regression appeared, we cannot deploy without a target node.

This is due to the fact that we don't have the same facilities to check for node before executing the designated function.

The check was performed only when the `target` argument was filled, which is not the case anymore.

Fix:
- Check the `target` only when a target is provided.
- Log the target being deployed only when a target is provided, else log: `TDP`