### PR TITLE
core: use "Popen.wait()" instead of "Popen.poll()"

### DIFF
--- a/tdp/core/runner/ansible_executor.py
+++ b/tdp/core/runner/ansible_executor.py
@@ -28,7 +28,7 @@ class AnsibleExecutor(Executor):
                 for stdout_line in iter(res.stdout.readline, ""):
                     print(stdout_line)
                     byte_stream.write(bytes(stdout_line, "utf-8"))
-                state = StateEnum.SUCCESS if res.poll() == 0 else StateEnum.FAILURE
+                state = StateEnum.SUCCESS if res.wait() == 0 else StateEnum.FAILURE
             except KeyboardInterrupt:
                 logger.debug("KeyboardInterrupt caught")
                 byte_stream.write(b"\nKeyboardInterrupt")


### PR DESCRIPTION
Fix #105 

Sometimes `poll()` is called before the process is finished so, sometimes, it returns `None`.