### PR TITLE
cli: add color-to option in dag

### DIFF
--- a/tdp/cli/commands/dag.py
+++ b/tdp/cli/commands/dag.py
@@ -46,8 +46,13 @@ DAG_SUMMARY = SHORT_DAG_SUMMARY + " Add node names to get a subgraph to the node
     flag_value="regex",
     help="Each node argument will be process as regex pattern",
 )
+@click.option(
+    "-ct",
+    "--color-to",
+    help="List of node to color to, separated with a comma (,)",
+)
 @pass_dag
-def dag(dag, nodes, transitive_reduction, pattern_format):
+def dag(dag, nodes, transitive_reduction, pattern_format, color_to):
     dag = Dag()
     graph = dag.graph
     if nodes:
@@ -73,4 +78,7 @@ def dag(dag, nodes, transitive_reduction, pattern_format):
         graph = graph.subgraph(ancestors)
     if transitive_reduction:
         graph = nx.transitive_reduction(graph)
-    show(graph)
+    node_to_colors = set()
+    if color_to:
+        node_to_colors.update(dag.get_actions_to_nodes(color_to.split(",")))
+    show(graph, node_to_colors)

--- a/tdp/core/dag_dot.py
+++ b/tdp/core/dag_dot.py
@@ -6,7 +6,9 @@ import networkx as nx
 
 # Needed :
 #   pip install pydot
-def to_pydot(graph):
+def to_pydot(graph, nodes_to_color=None):
+    if not nodes_to_color:
+        nodes_to_color = []
     pydot_graph = nx.nx_pydot.to_pydot(graph)
 
     dot_nodes = pydot_graph.get_nodes()
@@ -18,10 +20,17 @@ def to_pydot(graph):
 
     # Hack to add node defaults at the first position
     pydot_graph.set_node_defaults(shape="box", fontname="Roboto")
-
     for dot_node in dot_nodes:
+        if dot_node.get_name() in nodes_to_color:
+            dot_node.set_color("indianred")
+            dot_node.add_style("filled")
         pydot_graph.add_node(dot_node)
     for dot_edge in dot_edges:
+        if (
+            dot_edge.get_source() in nodes_to_color
+            and dot_edge.get_destination() in nodes_to_color
+        ):
+            dot_edge.set_color("indianred")
         pydot_graph.add_edge(dot_edge)
 
     return pydot_graph
@@ -30,9 +39,9 @@ def to_pydot(graph):
 # Needed :
 #   pip install matplotlib
 #   apt install graphviz
-def show(graph):
+def show(graph, nodes_to_color=None):
     if isinstance(graph, nx.classes.Graph):
-        graph = to_pydot(graph)
+        graph = to_pydot(graph, nodes_to_color)
 
     import io
     import matplotlib.pyplot as plt


### PR DESCRIPTION
While reviewing #114 I developped this (a version with `color-from` is coming after the validation of #114), it's a small improvement that allows to color nodes in the dag.

## Example with limited scope
`tdp dag zookeeper_init -ct zookeeper_config`
![Figure_1](https://user-images.githubusercontent.com/4944914/161780544-95633def-e194-4283-bd2b-5029a407b061.png)

## Example with full scope and multiple color-to targets
`tdp dag -ct spark_init,hbase_init`
![Figure_2](https://user-images.githubusercontent.com/4944914/161780755-84829d78-5fb0-4622-96f8-00d192e4d3ed.png)

