### PR TITLE
core: get copy of internal variables dict

### DIFF
--- a/tdp/core/variables.py
+++ b/tdp/core/variables.py
@@ -132,6 +132,9 @@ class VariablesDict:
                 cursor.pop(".".join(subkeys[index:]))
                 break
 
+    def to_dict(self):
+        return copy.deepcopy(self._content)
+
 
 class _VariablesIOWrapper(VariablesDict):
     def __init__(self, path):


### PR DESCRIPTION
fix #120 