### PR TITLE
cli: add color-from option in dag

### DIFF
--- a/tdp/cli/commands/dag.py
+++ b/tdp/cli/commands/dag.py
@@ -51,8 +51,14 @@ DAG_SUMMARY = SHORT_DAG_SUMMARY + " Add node names to get a subgraph to the node
     "--color-to",
     help="List of node to color to, separated with a comma (,)",
 )
+@click.option(
+    "-cf",
+    "--color-from",
+    help="Nodes that will be colored after applying get_actions_to_nodes, separed with a comma (,)",
+    type=str,
+)
 @pass_dag
-def dag(dag, nodes, transitive_reduction, pattern_format, color_to):
+def dag(dag, nodes, transitive_reduction, pattern_format, color_to, color_from):
     dag = Dag()
     graph = dag.graph
     if nodes:
@@ -78,7 +84,13 @@ def dag(dag, nodes, transitive_reduction, pattern_format, color_to):
         graph = graph.subgraph(ancestors)
     if transitive_reduction:
         graph = nx.transitive_reduction(graph)
-    node_to_colors = set()
+    nodes_to_color = set()
     if color_to:
-        node_to_colors.update(dag.get_actions_to_nodes(color_to.split(",")))
-    show(graph, node_to_colors)
+        nodes_to_color.update(dag.get_actions_to_nodes(color_to.split(",")))
+    if color_from:
+        nodes_from = dag.get_actions_from_nodes(color_from.split(","))
+        if nodes_to_color:
+            nodes_to_color = nodes_to_color.intersection(nodes_from)
+        else:
+            nodes_to_color = nodes_from
+    show(graph, nodes_to_color)


### PR DESCRIPTION
While reviewing https://github.com/TOSIT-IO/tdp-lib/pull/114 I developped this, it's a small improvement that allows to color nodes in the dag.

## Example with limited scope
`tdp dag zookeeper_init -cf zookeeper_config`
![Figure_1](https://user-images.githubusercontent.com/4944914/162757209-fd661aa9-d547-443b-a0a8-5811f8d61566.png)


## Example with full scope and multiple color-to targets
`tdp dag -cf spark_install,hbase_install`
![Figure_1](https://user-images.githubusercontent.com/4944914/162757339-f21467f3-ca97-4350-aaa4-620ed62428b8.png)

## Example to and from with limited scope
`tdp dag zookeeper_init -ct zookeeper_server_init -cf zookeeper_kerberos_install`

![Figure_1](https://user-images.githubusercontent.com/4944914/162757657-c5c94bc0-7b14-4f4f-a5e6-037275cf96ba.png)


/!\ Complex combinations might produce an output without colors, the goal is to simplify the code, keep in mind that it is not supported yet in the library to combine `targets` and `sources`
