### PR TITLE
Add "--cluster" for "dag" command to display node inside service

### DIFF
--- a/tdp/cli/__main__.py
+++ b/tdp/cli/__main__.py
@@ -12,7 +12,8 @@ from tdp.cli.commands.nodes import nodes
 from tdp.cli.commands.service_versions import service_versions
 from tdp.core.dag import Dag
 
-CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.pass_context

--- a/tdp/cli/commands/dag.py
+++ b/tdp/cli/commands/dag.py
@@ -57,8 +57,16 @@ DAG_SUMMARY = SHORT_DAG_SUMMARY + " Add node names to get a subgraph to the node
     help="Nodes that will be colored after applying get_actions_to_nodes, separed with a comma (,)",
     type=str,
 )
+@click.option(
+    "-c",
+    "--cluster",
+    is_flag=True,
+    help="Group node into cluster inside each service",
+)
 @pass_dag
-def dag(dag, nodes, transitive_reduction, pattern_format, color_to, color_from):
+def dag(
+    dag, nodes, transitive_reduction, pattern_format, color_to, color_from, cluster
+):
     dag = Dag()
     graph = dag.graph
     if nodes:
@@ -93,4 +101,4 @@ def dag(dag, nodes, transitive_reduction, pattern_format, color_to, color_from):
             nodes_to_color = nodes_to_color.intersection(nodes_from)
         else:
             nodes_to_color = nodes_from
-    show(graph, nodes_to_color)
+    show(graph, nodes_to_color, cluster)

--- a/tdp/core/dag_dot.py
+++ b/tdp/core/dag_dot.py
@@ -3,10 +3,12 @@
 
 import networkx as nx
 
+from tdp.core.component import Component
+
 
 # Needed :
 #   pip install pydot
-def to_pydot(graph, nodes_to_color=None):
+def to_pydot(graph, nodes_to_color=None, cluster_service=False):
     if not nodes_to_color:
         nodes_to_color = []
     pydot_graph = nx.nx_pydot.to_pydot(graph)
@@ -33,15 +35,33 @@ def to_pydot(graph, nodes_to_color=None):
             dot_edge.set_color("indianred")
         pydot_graph.add_edge(dot_edge)
 
+    if cluster_service:
+        import pydot
+
+        subgraphs = {}
+        for dot_node in dot_nodes:
+            # Dot node name can be quoted, remove it
+            component_name = dot_node.get_name().strip('"')
+            component = Component(component_name)
+            subgraphs.setdefault(
+                component.service,
+                pydot.Cluster(
+                    component.service, label=component.service, fontname="Roboto"
+                ),
+            ).add_node(pydot.Node(component_name))
+
+        for service_name, subgraph in sorted(subgraphs.items()):
+            pydot_graph.add_subgraph(subgraph)
+
     return pydot_graph
 
 
 # Needed :
 #   pip install matplotlib
 #   apt install graphviz
-def show(graph, nodes_to_color=None):
+def show(graph, *args, **kwargs):
     if isinstance(graph, nx.classes.Graph):
-        graph = to_pydot(graph, nodes_to_color)
+        graph = to_pydot(graph, *args, **kwargs)
 
     import io
     import matplotlib.pyplot as plt


### PR DESCRIPTION
The new option `--cluster` for `dag` command group nodes inside cluster subgraph for each service.

## Example

`tdp dag hdfs_init -c -ct ranger_init`
![tdp-lib-dag-cluster-color-to](https://user-images.githubusercontent.com/7147898/163560799-af68b494-cf81-48c3-a1ef-f850c788d7c6.png)

