### PR TITLE
docs: fix documentation generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ To generate the documentation:
 
 ```
 poetry install -E docs
-poetry run task docs-generate
+poetry run task docs-html
 ```


### PR DESCRIPTION
`docs-generate` is used to regenerate automatic rst files

To generate actual documentation, it's `docs-html`