### PR TITLE
core: timestamp without timezone, datetime from utc

### DIFF
--- a/tdp/core/models/action_log.py
+++ b/tdp/core/models/action_log.py
@@ -14,8 +14,8 @@ class ActionLog(Base):
 
     deployment_id = Column(Integer, ForeignKey("deployment_log.id"), primary_key=True)
     action = Column(String(length=NODE_NAME_MAX_LENGTH), primary_key=True)
-    start = Column(DateTime)
-    end = Column(DateTime)
+    start = Column(DateTime(timezone=False))
+    end = Column(DateTime(timezone=False))
     state = Column(String(length=StateEnum.max_length()))
     logs = Column(LargeBinary)
     deployment = relationship("DeploymentLog", back_populates="actions")

--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -16,8 +16,8 @@ class DeploymentLog(Base):
     sources = Column(JSON)
     targets = Column(JSON)
     filter = Column(String(length=NODE_NAME_MAX_LENGTH))
-    start = Column(DateTime)
-    end = Column(DateTime)
+    start = Column(DateTime(timezone=False))
+    end = Column(DateTime(timezone=False))
     state = Column(String(length=StateEnum.max_length()))
     actions = relationship(
         "ActionLog", back_populates="deployment", order_by="ActionLog.start"

--- a/tdp/core/models/test_db.py
+++ b/tdp/core/models/test_db.py
@@ -25,12 +25,15 @@ def session_class():
 
 def test_add_object(session_class):
     deployment = DeploymentLog(
-        targets=["init_hdfs"], start=datetime.now(), end=datetime.now(), state="SUCCESS"
+        targets=["init_hdfs"],
+        start=datetime.utcnow(),
+        end=datetime.utcnow(),
+        state="SUCCESS",
     )
     action = ActionLog(
         action="start_hdfs",
-        start=datetime.now(),
-        end=datetime.now(),
+        start=datetime.utcnow(),
+        end=datetime.utcnow(),
         state="SUCCESS",
         logs=b"log",
     )

--- a/tdp/core/runner/action_runner.py
+++ b/tdp/core/runner/action_runner.py
@@ -23,9 +23,9 @@ class ActionRunner:
     def run(self, action):
         logger.debug(f"Running action {action}")
 
-        start = datetime.now()
+        start = datetime.utcnow()
         state, logs = self._executor.execute(action)
-        end = datetime.now()
+        end = datetime.utcnow()
 
         if not StateEnum.has_value(state):
             logger.error(
@@ -78,9 +78,9 @@ class ActionRunner:
         elif node_filter:
             actions = self.dag.filter_actions_glob(actions, node_filter)
 
-        start = datetime.now()
+        start = datetime.utcnow()
         action_logs = list(self._run_actions(actions))
-        end = datetime.now()
+        end = datetime.utcnow()
 
         filtered_failures = filter(
             lambda action_log: action_log.state == StateEnum.FAILURE.value, action_logs


### PR DESCRIPTION
fix #81 

In this PR:
- explicitly set Timestamp without Timezone
- use `utcnow()`, instead of `now()`