### PR TITLE
core: prevent empty commits in git_repository

### DIFF
--- a/tdp/core/repository/git_repository.py
+++ b/tdp/core/repository/git_repository.py
@@ -4,9 +4,14 @@
 import logging
 from contextlib import contextmanager
 
-from git import InvalidGitRepositoryError, NoSuchPathError, Repo
+from git import BadName, InvalidGitRepositoryError, NoSuchPathError, Repo
 
-from tdp.core.repository.repository import NotARepository, NoVersionYet, Repository
+from tdp.core.repository.repository import (
+    EmptyCommit,
+    NotARepository,
+    NoVersionYet,
+    Repository,
+)
 
 logger = logging.getLogger("tdp").getChild("git_repository")
 
@@ -41,8 +46,18 @@ class GitRepository(Repository):
     def validate(self, msg):
         with self._lock:
             yield self
-            commit = self._repo.index.commit(msg)
-            logger.info(f"commit: [{commit.hexsha}] {msg}")
+            try:
+                if len(self._repo.index.diff("HEAD")) > 0:
+                    commit = self._repo.index.commit(msg)
+                    logger.info(f"commit: [{commit.hexsha}] {msg}")
+                else:
+                    raise EmptyCommit("The commit has no diff")
+            except BadName as e:
+                logger.debug(
+                    f"error during diff: {e}. Probably because the repo is still empty."
+                )
+                commit = self._repo.index.commit(msg)
+                logger.info(f"commit: [{commit.hexsha}] {msg}")
 
     def add_for_validation(self, path):
         with self._lock:

--- a/tdp/core/repository/repository.py
+++ b/tdp/core/repository/repository.py
@@ -21,6 +21,10 @@ class NotARepository(Exception):
     pass
 
 
+class EmptyCommit(Exception):
+    pass
+
+
 class Repository(ABC):
     """Abstract class representing a versionned repository.
 


### PR DESCRIPTION
Fix #143 

I am really not sure this is the best way to do this thought.

**Note: ** I had to use `--no-verify` to commit as `isort` and `black` seem to counter each other. Runnin the commands gives the same output over and over:

```
isort --recursive tdp && black tdp
Fixing /home/leo/TOSIT-FR/tdp-lib/tdp/core/repository/test_git_repository.py
Fixing /home/leo/TOSIT-FR/tdp-lib/tdp/core/repository/git_repository.py
reformatted tdp/core/repository/git_repository.py
reformatted tdp/core/repository/test_git_repository.py
All done! ✨ 🍰 ✨
2 files reformatted, 35 files left unchanged.
```