### PR TITLE
cli: sql query improvement for tdp service-versions

### DIFF
--- a/tdp/cli/commands/service_versions.py
+++ b/tdp/cli/commands/service_versions.py
@@ -4,12 +4,11 @@
 from pathlib import Path
 
 import click
-from sqlalchemy import func, select, tuple_
+from sqlalchemy import and_, func
 from tabulate import tabulate
 
 from tdp.cli.session import get_session_class
-from tdp.core.models import ServiceLog
-from tdp.core.models.base import keyvalgen
+from tdp.core.models import OperationLog, ServiceLog
 
 
 @click.command(
@@ -28,42 +27,32 @@ from tdp.core.models.base import keyvalgen
 def service_versions(sqlite_path):
     session_class = get_session_class(sqlite_path)
     with session_class() as session:
-        service_headers = [
-            key for key, _ in keyvalgen(ServiceLog) if key != "deployment"
-        ]
 
-        latest_deployment_by_service = select(
-            func.max(ServiceLog.deployment_id), ServiceLog.service
-        ).group_by(ServiceLog.service)
-
-        service_latest_version = (
-            session.query(ServiceLog)
-            .order_by(ServiceLog.deployment_id.desc())
-            .filter(
-                tuple_(ServiceLog.deployment_id, ServiceLog.service).in_(
-                    latest_deployment_by_service
-                )
+        latest_success_service_version = (
+            session.query(
+                func.max(ServiceLog.deployment_id).label("deployment_id"),
+                ServiceLog.service.label("service"),
+                func.substr(ServiceLog.version, 1, 7).label("version"),
             )
+            .join(
+                OperationLog,
+                and_(
+                    ServiceLog.deployment_id == OperationLog.deployment_id,
+                    OperationLog.operation.like(
+                        ServiceLog.service + "\_%", escape="\\"
+                    ),
+                ),
+            )
+            .filter(OperationLog.state == "Success")
+            .group_by(ServiceLog.service, ServiceLog.version)
+            .order_by("deployment_id", "service")
             .all()
         )
 
         click.echo(
             "Service versions:\n"
             + tabulate(
-                [
-                    format_service_log(service_log, service_headers)
-                    for service_log in service_latest_version
-                ],
-                headers="keys",
+                latest_success_service_version,
+                headers=["deployment_id", "service", "version"],
             )
         )
-
-
-def format_service_log(service_log, headers):
-    def custom_format(key, value):
-        if key == "version":
-            return str(value[:7])
-        else:
-            return str(value)
-
-    return {key: custom_format(key, getattr(service_log, key)) for key in headers}


### PR DESCRIPTION
Fixes #182

Modify ```sqlalchemy``` code to take into account the following SQL query:
```
SELECT max(service_log.deployment_id) AS deployment_id,service_log.service AS service,substr(service_log.version,1,7) AS version
FROM service_log JOIN operation_log
ON (service_log.deployment_id = operation_log.deployment_id AND operation_log.operation LIKE service_log.service || '\_%' ESCAPE '\')
WHERE operation_log.state = 'Success'
GROUP BY service_log.service,service_log.version
ORDER BY deployment_id,service;
```