### PR TITLE
feat: replace sqlite-path argument with database-dsn

### DIFF
--- a/docs/developer/cli/developer_quick_start.rst
+++ b/docs/developer/cli/developer_quick_start.rst
@@ -19,7 +19,7 @@ Developer Quick Start (sqlite backend)
      # this folder is working directory of tdp deployment in which you put ansible.cfg, inventory.ini and topology.ini.
      user@yourmachine:export TDP_RUN_DIRECTORY=~/working-dir
      # this folder is to store sqlite db file
-     user@yourmachine:export TDP_SQLITE_PATH=~/sqlite-data/tdp.db
+     user@yourmachine:export TDP_DATABASE_DSN=sqlite:////data/sqlite-data/tdp.db
      # this folder is to store tdp service configuration, please find default values at $TDP_COLLECTION_PATH/tdp_vars_defaults
      # you must NOT set TDP_VARS to $TDP_COLLECTION_PATH/tdp_vars_defaults
      # the path must contain the string `tdp_vars`

--- a/tdp/cli/commands/browse.py
+++ b/tdp/cli/commands/browse.py
@@ -19,11 +19,16 @@ LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
 @click.argument("deployment_id", required=False)
 @click.argument("operation", required=False)
 @click.option(
-    "--sqlite-path",
-    envvar="TDP_SQLITE_PATH",
+    "--database-dsn",
+    envvar="TDP_DATABASE_DSN",
     required=True,
-    type=Path,
-    help="Path to SQLITE database file",
+    type=str,
+    help=(
+        "Database Data Source Name, in sqlalchemy driver form "
+        "example: sqlite:////data/tdp.db or sqlite+pysqlite:////data/tdp.db. "
+        "You might need to install the relevant driver to your installation (such "
+        "as psycopg2 for postgresql)"
+    ),
 )
 @click.option(
     "--limit",
@@ -39,8 +44,8 @@ LOCAL_TIMEZONE = datetime.now(timezone.utc).astimezone().tzinfo
     default=0,
     help="At which offset should the database query should start",
 )
-def browse(deployment_id, operation, sqlite_path, limit, offset):
-    session_class = get_session_class(sqlite_path)
+def browse(deployment_id, operation, database_dsn, limit, offset):
+    session_class = get_session_class(database_dsn)
 
     if not deployment_id:
         process_deployments_query(session_class, limit, offset)

--- a/tdp/cli/commands/deploy.py
+++ b/tdp/cli/commands/deploy.py
@@ -28,11 +28,16 @@ from tdp.core.service_manager import ServiceManager
     help="Nodes where the run stop (separate with comma)",
 )
 @click.option(
-    "--sqlite-path",
-    envvar="TDP_SQLITE_PATH",
-    type=Path,
-    help="Path to SQLITE database file",
+    "--database-dsn",
+    envvar="TDP_DATABASE_DSN",
     required=True,
+    type=str,
+    help=(
+        "Database Data Source Name, in sqlalchemy driver form "
+        "example: sqlite:////data/tdp.db or sqlite+pysqlite:////data/tdp.db. "
+        "You might need to install the relevant driver to your installation (such "
+        "as psycopg2 for postgresql)"
+    ),
 )
 @click.option(
     "--collection-path",
@@ -56,7 +61,7 @@ from tdp.core.service_manager import ServiceManager
 def deploy(
     sources,
     targets,
-    sqlite_path,
+    database_dsn,
     collection_path,
     run_directory,
     vars,
@@ -82,7 +87,7 @@ def deploy(
         run_directory=run_directory,
         dry=dry,
     )
-    session_class = get_session_class(sqlite_path)
+    session_class = get_session_class(database_dsn)
     with session_class() as session:
         service_managers = ServiceManager.get_service_managers(dag, vars)
         check_services_cleanliness(service_managers)

--- a/tdp/cli/commands/init.py
+++ b/tdp/cli/commands/init.py
@@ -15,11 +15,16 @@ from tdp.core.service_manager import ServiceManager
 
 @click.command(short_help="Init database / services in tdp vars")
 @click.option(
-    "--sqlite-path",
-    envvar="TDP_SQLITE_PATH",
+    "--database-dsn",
+    envvar="TDP_DATABASE_DSN",
     required=True,
-    type=Path,
-    help="Path to SQLITE database file",
+    type=str,
+    help=(
+        "Database Data Source Name, in sqlalchemy driver form "
+        "example: sqlite:////data/tdp.db or sqlite+pysqlite:////data/tdp.db. "
+        "You might need to install the relevant driver to your installation (such "
+        "as psycopg2 for postgresql)"
+    ),
 )
 @click.option(
     "--collection-path",
@@ -31,9 +36,9 @@ from tdp.core.service_manager import ServiceManager
 @click.option(
     "--vars", envvar="TDP_VARS", required=True, type=Path, help="Path to the tdp vars"
 )
-def init(sqlite_path, collection_path, vars):
+def init(database_dsn, collection_path, vars):
     dag = Dag.from_collections(collection_path)
-    init_db(sqlite_path)
+    init_db(database_dsn)
     service_managers = ServiceManager.initialize_service_managers(dag, vars)
     for name, service_manager in service_managers.items():
         try:

--- a/tdp/cli/commands/run.py
+++ b/tdp/cli/commands/run.py
@@ -17,11 +17,16 @@ from tdp.core.service_manager import ServiceManager
 @click.command(short_help="Run single TDP operation")
 @click.argument("node")
 @click.option(
-    "--sqlite-path",
-    envvar="TDP_SQLITE_PATH",
-    type=Path,
-    help="Path to SQLITE database file",
+    "--database-dsn",
+    envvar="TDP_DATABASE_DSN",
     required=True,
+    type=str,
+    help=(
+        "Database Data Source Name, in sqlalchemy driver form "
+        "example: sqlite:////data/tdp.db or sqlite+pysqlite:////data/tdp.db. "
+        "You might need to install the relevant driver to your installation (such "
+        "as psycopg2 for postgresql)"
+    ),
 )
 @click.option(
     "--collection-path",
@@ -43,7 +48,7 @@ from tdp.core.service_manager import ServiceManager
 @click.option("--dry", is_flag=True, help="Execute dag without running any operation")
 def run(
     node,
-    sqlite_path,
+    database_dsn,
     collection_path,
     run_directory,
     vars,
@@ -69,7 +74,7 @@ def run(
         run_directory=run_directory,
         dry=dry,
     )
-    session_class = get_session_class(sqlite_path)
+    session_class = get_session_class(database_dsn)
     with session_class() as session:
         service_managers = ServiceManager.get_service_managers(dag, vars)
         check_services_cleanliness(service_managers)

--- a/tdp/cli/commands/service_versions.py
+++ b/tdp/cli/commands/service_versions.py
@@ -18,14 +18,19 @@ from tdp.core.models import OperationLog, ServiceLog
     )
 )
 @click.option(
-    "--sqlite-path",
-    envvar="TDP_SQLITE_PATH",
+    "--database-dsn",
+    envvar="TDP_DATABASE_DSN",
     required=True,
-    type=Path,
-    help="Path to SQLITE database file",
+    type=str,
+    help=(
+        "Database Data Source Name, in sqlalchemy driver form "
+        "example: sqlite:////data/tdp.db or sqlite+pysqlite:////data/tdp.db. "
+        "You might need to install the relevant driver to your installation (such "
+        "as psycopg2 for postgresql)"
+    ),
 )
-def service_versions(sqlite_path):
-    session_class = get_session_class(sqlite_path)
+def service_versions(database_dsn):
+    session_class = get_session_class(database_dsn)
     with session_class() as session:
 
         latest_success_service_version = (

--- a/tdp/cli/session.py
+++ b/tdp/cli/session.py
@@ -7,25 +7,15 @@ from sqlalchemy.orm import sessionmaker
 from tdp.core.models import init_database
 
 
-def path_or_inmemory(path):
-    return path.absolute() if path else ":memory:"
-
-
-def get_session_class(sqlite_path=None):
-    if sqlite_path and not sqlite_path.exists():
-        raise ValueError(
-            "a sqlite path has been set, but the path does not exist, run `tdp init`"
-        )
-    path = path_or_inmemory(sqlite_path)
-    engine = create_engine(f"sqlite+pysqlite:///{path}", echo=False, future=True)
+def get_session_class(database_dsn):
+    engine = create_engine(database_dsn, echo=False, future=True)
     session_class = sessionmaker(bind=engine)
 
     return session_class
 
 
-def init_db(sqlite_path=None):
-    path = path_or_inmemory(sqlite_path)
+def init_db(database_dsn):
     engine = create_engine(
-        f"sqlite+pysqlite:///{path}", echo=True, future=True
+        database_dsn, echo=True, future=True
     )  # Echo = True to get logs
     init_database(engine)


### PR DESCRIPTION
fix #184

/!\ Breaking change, `sqlite-path` replaced by `database-dsn`

This PR introduces the argument `database-dsn` as a replacement to `sqlite-path`.
The argument does not take a path anymore, but an sqlalchemy compatible datasource name (dsn).

Example for sqlite:
```bash
# Notice the 4 '/' to indicate an absolute path
export TDP_DATABASE_DSN="sqlite:////data/tdp.db"
```

Example for postgresql:
```bash
export TDP_DATABASE_DSN="postgresql://tdp_user:tdp_password@localhost/tdp_dev_db"
```

If you use a sqlite backend, there's no python driver to install, since it's present in the standard library (you might need to install sqlite3 on your system though).

If you use another backend, such as Postgresql, you need to install the relevant python driver such a `psycopg2` or `psycopg2-binary` for instance.