### PR TITLE
cli: fix service-versions sql query labels

### DIFF
--- a/tdp/cli/commands/service_versions.py
+++ b/tdp/cli/commands/service_versions.py
@@ -9,6 +9,7 @@ from tabulate import tabulate
 
 from tdp.cli.session import get_session_class
 from tdp.core.models import OperationLog, ServiceLog
+from tdp.core.runner.executor import StateEnum
 
 
 @click.command(
@@ -49,7 +50,7 @@ def service_versions(database_dsn):
                     ),
                 ),
             )
-            .filter(OperationLog.state == "Success")
+            .filter(OperationLog.state == StateEnum.SUCCESS.value)
             .group_by(ServiceLog.service, ServiceLog.version)
             .order_by(max_depid_label, ServiceLog.service)
             .all()


### PR DESCRIPTION
Fixes #188 

This will remove hard coded strings defined in the SQL query labels used by the client command line ```tdp service-versions```. Thoses are not used are completely removed.
For which is used, it is replaced by variable. And strings in result header are also replaced by variables.
