### PR TITLE
Run Operation not in DAG

### DIFF
--- a/tdp/cli/commands/dag.py
+++ b/tdp/cli/commands/dag.py
@@ -72,7 +72,7 @@ def dag(
     cluster,
 ):
     show = import_show()
-    dag = Dag.from_collections(collection_path)
+    dag = Dag(collection_path)
     graph = dag.graph
     if nodes:
         if pattern_format:

--- a/tdp/cli/commands/default_diff.py
+++ b/tdp/cli/commands/default_diff.py
@@ -31,7 +31,7 @@ from tdp.core.variables import Variables
 def default_diff(service, collection_path, vars):
     if not vars.exists():
         raise click.BadParameter(f"{vars} does not exist")
-    dag = Dag.from_collections(collection_path)
+    dag = Dag(collection_path)
     service_managers = ServiceManager.get_service_managers(dag, vars)
 
     if service:

--- a/tdp/cli/commands/deploy.py
+++ b/tdp/cli/commands/deploy.py
@@ -70,7 +70,7 @@ def deploy(
 ):
     if not vars.exists():
         raise click.BadParameter(f"{vars} does not exist")
-    dag = Dag.from_collections(collection_path)
+    dag = Dag(collection_path)
     set_nodes = set()
     if sources:
         sources = sources.split(",")

--- a/tdp/cli/commands/init.py
+++ b/tdp/cli/commands/init.py
@@ -37,7 +37,7 @@ from tdp.core.service_manager import ServiceManager
     "--vars", envvar="TDP_VARS", required=True, type=Path, help="Path to the tdp vars"
 )
 def init(database_dsn, collection_path, vars):
-    dag = Dag.from_collections(collection_path)
+    dag = Dag(collection_path)
     init_db(database_dsn)
     service_managers = ServiceManager.initialize_service_managers(dag, vars)
     for name, service_manager in service_managers.items():

--- a/tdp/cli/commands/nodes.py
+++ b/tdp/cli/commands/nodes.py
@@ -19,7 +19,7 @@ from tdp.core.dag import Dag
     help=f"List of paths separated by your os' path separator ({os.pathsep})",
 )
 def nodes(collection_path):
-    dag = Dag.from_collections(collection_path)
+    dag = Dag(collection_path)
     endline = "\n- "
     operations = endline.join(operation for operation in dag.get_all_operations())
     click.echo(f"Operation list:{endline}{operations}")

--- a/tdp/cli/commands/playbooks.py
+++ b/tdp/cli/commands/playbooks.py
@@ -31,7 +31,7 @@ from tdp.core.operation import Operation
     default=".",
 )
 def playbooks(services, collection_path, output_dir):
-    dag = Dag.from_collections(collection_path)
+    dag = Dag(collection_path)
     # services DAG
     dag_services = nx.DiGraph()
     # For each service, get all operations with DAG topological_sort order

--- a/tdp/cli/commands/run.py
+++ b/tdp/cli/commands/run.py
@@ -56,7 +56,7 @@ def run(
 ):
     if not vars.exists():
         raise click.BadParameter(f"{vars} does not exist")
-    dag = Dag.from_collections(collection_path)
+    dag = Dag(collection_path)
 
     operation = dag.operations.get(node, None)
     if not operation:

--- a/tdp/cli/utils.py
+++ b/tdp/cli/utils.py
@@ -6,13 +6,17 @@ import os
 import click
 
 from tdp.core.collection import Collection
+from tdp.core.collections import Collections
 
 
 def collection_paths(ctx, param, value):
     if not value:
         raise click.BadParameter("cannot be empty", ctx=ctx, param=param)
 
-    collections = [Collection.from_path(split) for split in value.split(os.pathsep)]
+    collections_list = [
+        Collection.from_path(split) for split in value.split(os.pathsep)
+    ]
+    collections = Collections.from_collection_list(collections_list)
 
     return collections
 

--- a/tdp/core/collections.py
+++ b/tdp/core/collections.py
@@ -1,0 +1,119 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from collections import OrderedDict
+from collections.abc import Mapping
+
+import yaml
+
+from tdp.core.operation import Operation
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+logger = logging.getLogger("tdp").getChild("collections")
+
+
+class Collections(Mapping):
+    def __init__(self, collections):
+        self._collections = collections
+        self._dag_operations = None
+        self._other_operations = None
+        self._init_operations()
+
+    def __getitem__(self, key):
+        return self._collections.__getitem__(key)
+
+    def __iter__(self):
+        return self._collections.__iter__()
+
+    def __len__(self):
+        return self._collections.__len__()
+
+    @staticmethod
+    def from_collection_list(collections):
+        """Factory method to build Collections from Ordered Sequence of Collection object
+
+        Ordering of the sequence is what will determine the loading order of the operations.
+        An operation can override a previous operation.
+
+        :param collections: Ordered Sequence of Collection
+        :type collections: Sequence[Collection]
+        :return: Collections built from x collections
+        :rtype: Collections
+        """
+        collections = OrderedDict(
+            (collection.name, collection) for collection in collections
+        )
+
+        return Collections(collections)
+
+    @property
+    def collections(self):
+        return self._collections
+
+    @collections.setter
+    def collections(self, collections):
+        self._collections = collections
+        self._init_operations()
+
+    @property
+    def dag_operations(self):
+        return self._dag_operations
+
+    @property
+    def other_operations(self):
+        return self._other_operations
+
+    @property
+    def operations(self):
+        operations = {}
+        if self._dag_operations:
+            operations.update(self._dag_operations)
+        if self._other_operations:
+            operations.update(self._other_operations)
+        return operations
+
+    def _init_operations(self):
+        self._dag_operations = {}
+        self._other_operations = {}
+
+        # Init DAG Operations
+        for collection_name, collection in self._collections.items():
+            for yaml_file in collection.dag_yamls:
+                operations_list = None
+                with yaml_file.open("r") as operation_file:
+                    operations_list = yaml.load(operation_file, Loader=Loader) or []
+
+                for operation in operations_list:
+                    name = operation["name"]
+                    if name in self._dag_operations:
+                        logger.info(
+                            f"DAG Operation '{name}' defined in collection "
+                            f"'{self._dag_operations[name].collection_name}' "
+                            f"is overridden by collection '{collection_name}'"
+                        )
+
+                    self._dag_operations[name] = Operation(
+                        collection_name=collection_name, **operation
+                    )
+
+        # Init Operations not in the DAG
+        for collection_name, collection in self._collections.items():
+            for operation_name, operation_file in collection.operations.items():
+                if operation_name in self._dag_operations:
+                    continue
+                if operation_name in self._other_operations:
+                    logger.info(
+                        f"Operation '{operation_name}' defined in collection "
+                        f"'{self._other_operations[operation_name].collection_name}' "
+                        f"is overridden by collection '{collection_name}'"
+                    )
+
+                self._other_operations[operation_name] = Operation(
+                    name=operation_name,
+                    collection_name=collection_name,
+                )

--- a/tdp/core/runner/operation_runner.py
+++ b/tdp/core/runner/operation_runner.py
@@ -41,7 +41,7 @@ class OperationRunner:
 
     def _run_operations(self, operation_names):
         for operation_name in operation_names:
-            operation = self.dag.operations[operation_name]
+            operation = self.dag.collections.operations[operation_name]
             if not operation.noop:
                 operation_file = self.dag.collections[
                     operation.collection_name
@@ -57,9 +57,9 @@ class OperationRunner:
     def _services_from_operations(self, operation_names):
         """Returns a set of services from an operation list"""
         return {
-            self.dag.operations[operation_name].service
+            self.dag.collections.operations[operation_name].service
             for operation_name in operation_names
-            if not self.dag.operations[operation_name].noop
+            if not self.dag.collections.operations[operation_name].noop
         }
 
     def _build_service_logs(self, operation_logs):


### PR DESCRIPTION
Fix #190 

Add `Collections` class to handle collections order.

`Collections` class is used to load `Operation` from multiple `Collection` object. `Collections` allow to have `Collection` which override `Operation` from a previous loaded `Collection`. The loading order is important.

Moreover `Collections` handle `Operation` inside the DAG and `Operation` not in the DAG.