### PR TITLE
cli: remove operations in tdp browse deployments

### DIFF
--- a/tdp/cli/commands/browse.py
+++ b/tdp/cli/commands/browse.py
@@ -57,7 +57,9 @@ def browse(deployment_id, operation, database_dsn, limit, offset):
 
 
 def process_deployments_query(session_class, limit, offset):
-    headers = [key for key, _ in keyvalgen(DeploymentLog)]
+    headers = DeploymentLog.__table__.columns.keys() + [
+        str(DeploymentLog.services).split(".")[1]
+    ]
     query = select(DeploymentLog).order_by(DeploymentLog.id).limit(limit).offset(offset)
 
     with session_class() as session:
@@ -75,7 +77,9 @@ def process_deployments_query(session_class, limit, offset):
 
 
 def process_single_deployment_query(session_class, deployment_id):
-    deployment_headers = [key for key, _ in keyvalgen(DeploymentLog)]
+    deployment_headers = DeploymentLog.__table__.columns.keys() + [
+        str(DeploymentLog.services).split(".")[1]
+    ]
     operation_headers = [key for key, _ in keyvalgen(OperationLog)]
     service_headers = [key for key, _ in keyvalgen(ServiceLog) if key != "deployment"]
     operation_headers.remove("deployment")
@@ -173,11 +177,6 @@ def format_deployment_log(deployment_log, headers):
                 return value[0] + ",...," + value[-1]
             else:
                 return ",".join(value)
-        elif key == "operations":
-            if len(value) > 2:
-                return value[0].operation + ",...," + value[-1].operation
-            else:
-                return ",".join(operation_log.operation for operation_log in value)
         elif key == "services":
             return ",".join(str(service_log.service) for service_log in value)
         elif isinstance(value, datetime):

--- a/tdp/cli/commands/browse.py
+++ b/tdp/cli/commands/browse.py
@@ -77,9 +77,7 @@ def process_deployments_query(session_class, limit, offset):
 
 
 def process_single_deployment_query(session_class, deployment_id):
-    deployment_headers = DeploymentLog.__table__.columns.keys() + [
-        str(DeploymentLog.services).split(".")[1]
-    ]
+    deployment_headers = [key for key, _ in keyvalgen(DeploymentLog)]
     operation_headers = [key for key, _ in keyvalgen(OperationLog)]
     service_headers = [key for key, _ in keyvalgen(ServiceLog) if key != "deployment"]
     operation_headers.remove("deployment")
@@ -177,6 +175,11 @@ def format_deployment_log(deployment_log, headers):
                 return value[0] + ",...," + value[-1]
             else:
                 return ",".join(value)
+        elif key == "operations":
+            if len(value) > 2:
+                return value[0].operation + ",...," + value[-1].operation
+            else:
+                return ",".join(operation_log.operation for operation_log in value)
         elif key == "services":
             return ",".join(str(service_log.service) for service_log in value)
         elif isinstance(value, datetime):


### PR DESCRIPTION
Fix #196 

The column about ```operations``` in ```deployments``` returned by ```tdp browse``` could be removed, because it can not contain a full list of operations, and this could be display with ```tdp browse <deployment_id>```.

By this way, we could thus reduce number of queries launched by ```tdp browse```.