### PR TITLE
feat(models): make DeploymentLog explicitly inheritable

### DIFF
--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -19,7 +19,13 @@ class DeploymentLog(Base):
     start = Column(DateTime(timezone=False))
     end = Column(DateTime(timezone=False))
     state = Column(String(length=StateEnum.max_length()))
+    type = Column(String(length=50))
     operations = relationship(
         "OperationLog", back_populates="deployment", order_by="OperationLog.start"
     )
     services = relationship("ServiceLog", back_populates="deployment")
+
+    __mapper_args__ = {
+        "polymorphic_identity": __tablename__,
+        "polymorphic_on": type,
+    }


### PR DESCRIPTION
fix #199

This pr enables SQLAlchemy polymorphism to allow outside use (such as tdp-server), to cleanly inherit from this table and enrich it with more data.