### PR TITLE
fix(cli): add *_config and *_restart filters for restart_required exe…

### DIFF
--- a/tdp/cli/commands/restart_required.py
+++ b/tdp/cli/commands/restart_required.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import re
 from pathlib import Path
 
 import click
@@ -92,6 +93,7 @@ def restart_required(
         deployment = operation_runner.run_nodes(
             sources=list(components_modified),
             restart=True,
+            node_filter=re.compile(r".+_(config|start)"),
         )
         session.add(deployment)
         session.commit()


### PR DESCRIPTION
Fixes #201 

**Execution Plan Example :**
```
------------------------------------- Config -------------------------------------
2022-07-29 15:29:33,061 -      hadoop_client_config.yml
2022-07-29 15:29:33,061 -      ranger_admin_config.yml
2022-07-29 15:29:33,061 -      ranger_kms_config.yml
2022-07-29 15:29:33,061 -      ranger_usersync_config.yml
2022-07-29 15:29:33,062 -      hdfs_datanode_config.yml
2022-07-29 15:29:33,062 -      hdfs_jmx-exporter_config.yml
2022-07-29 15:29:33,062 -      hdfs_journalnode_config.yml
2022-07-29 15:29:33,062 -      hdfs_namenode_config.yml
2022-07-29 15:29:33,062 -      hdfs_client_config.yml
2022-07-29 15:29:33,062 -      hdfs_ranger_config.yml
2022-07-29 15:29:33,065 -      yarn_apptimelineserver_config.yml
2022-07-29 15:29:33,065 -      yarn_mapred_jobhistoryserver_config.yml
2022-07-29 15:29:33,065 -      yarn_nodemanager_config.yml
2022-07-29 15:29:33,065 -      yarn_resourcemanager_config.yml
2022-07-29 15:29:33,065 -      yarn_client_config.yml
2022-07-29 15:29:33,065 -      yarn_ranger_config.yml
2022-07-29 15:29:33,065 -      hive_client_config.yml
2022-07-29 15:29:33,066 -      hive_hiveserver2_config.yml
2022-07-29 15:29:33,066 -      hive_metastore_config.yml
2022-07-29 15:29:33,066 -      hive_ranger_config.yml
2022-07-29 15:29:33,066 -      hbase_client_config.yml
2022-07-29 15:29:33,066 -      hbase_jmx-exporter_config.yml
2022-07-29 15:29:33,066 -      hbase_master_config.yml
2022-07-29 15:29:33,066 -      hbase_phoenix_queryserver_client_config.yml
2022-07-29 15:29:33,066 -      hbase_phoenix_queryserver_daemon_config.yml
2022-07-29 15:29:33,067 -      hbase_regionserver_config.yml
2022-07-29 15:29:33,067 -      hbase_ranger_config.yml
2022-07-29 15:29:33,067 -      hbase_rest_config.yml
2022-07-29 15:29:33,067 -      spark_client_config.yml
2022-07-29 15:29:33,067 -      spark_historyserver_config.yml
2022-07-29 15:29:33,067 -      spark3_client_config.yml
2022-07-29 15:29:33,067 -      spark3_historyserver_config.yml
2022-07-29 15:29:33,068 -      knox_gateway_config.yml
2022-07-29 15:29:33,068 -      knox_ranger_config.yml

------------------------------------- Restart -------------------------------------

2022-07-29 15:29:33,078 -      ranger_admin_restart.yml
2022-07-29 15:29:33,078 -      ranger_usersync_restart.yml
2022-07-29 15:29:33,078 -      ranger_kms_restart.yml
2022-07-29 15:29:33,078 -      hdfs_journalnode_restart.yml
2022-07-29 15:29:33,079 -      hdfs_namenode_restart.yml
2022-07-29 15:29:33,079 -      hdfs_datanode_restart.yml
2022-07-29 15:29:33,079 -      yarn_apptimelineserver_restart.yml
2022-07-29 15:29:33,079 -      yarn_mapred_jobhistoryserver_restart.yml
2022-07-29 15:29:33,079 -      yarn_resourcemanager_restart.yml
2022-07-29 15:29:33,079 -      yarn_nodemanager_restart.yml
2022-07-29 15:29:33,079 -      hive_metastore_restart.yml
2022-07-29 15:29:33,080 -      hive_hiveserver2_restart.yml
2022-07-29 15:29:33,080 -      hbase_master_restart.yml
2022-07-29 15:29:33,080 -      hbase_regionserver_restart.yml
2022-07-29 15:29:33,080 -      hbase_rest_restart.yml
2022-07-29 15:29:33,080 -      hbase_phoenix_queryserver_daemon_restart.yml
2022-07-29 15:29:33,080 -      spark_historyserver_restart.yml
2022-07-29 15:29:33,081 -      spark3_historyserver_restart.yml
2022-07-29 15:29:33,081 -      knox_gateway_restart.yml


```