### PR TITLE
feat: update operations during deployment

### DIFF
--- a/tdp/cli/commands/deploy.py
+++ b/tdp/cli/commands/deploy.py
@@ -99,8 +99,15 @@ def deploy(
             click.echo(f"Deploying to {targets}")
         else:
             click.echo(f"Deploying TDP")
-        deployment = operation_runner.run_nodes(
+        operation_iterator = operation_runner.run_nodes(
             sources=sources, targets=targets, node_filter=filter
         )
-        session.add(deployment)
+        session.add(operation_iterator.deployment_log)
+        # insert pending deployment log
+        session.commit()
+        for operation in operation_iterator:
+            session.add(operation)
+            session.commit()
+        # notify sqlalchemy deployment log has been updated
+        session.merge(operation_iterator.deployment_log)
         session.commit()

--- a/tdp/cli/commands/run.py
+++ b/tdp/cli/commands/run.py
@@ -81,6 +81,15 @@ def run(
 
         operation_runner = OperationRunner(dag, ansible_executor, service_managers)
         click.echo(f"Deploying {node}")
-        deployment = operation_runner.run_nodes(targets=[node], node_filter=node)
-        session.add(deployment)
+        operation_iterator = operation_runner.run_nodes(
+            targets=[node], node_filter=node
+        )
+        session.add(operation_iterator.deployment_log)
+        # insert pending deployment log
+        session.commit()
+        for operation in operation_iterator:
+            session.add(operation)
+            session.commit()
+        # notify sqlalchemy deployment log has been updated
+        session.merge(operation_iterator.deployment_log)
         session.commit()

--- a/tdp/core/runner/executor.py
+++ b/tdp/core/runner/executor.py
@@ -8,6 +8,7 @@ from enum import Enum
 class StateEnum(Enum):
     SUCCESS = "Success"
     FAILURE = "Failure"
+    PENDING = "Pending"
 
     @classmethod
     def has_value(cls, value):


### PR DESCRIPTION
fix #204

In this PR:
- run_nodes now returns an iterator, giving back control to the deployment to the caller. It is still the caller responsibility to insert into database. An user can iterate through all the operations, and only insert the final deployment log. Or, he can insert along the way.