### PR TITLE
feat: modify sql schema attribute not to use reserved keywords

### DIFF
--- a/tdp/cli/commands/browse.py
+++ b/tdp/cli/commands/browse.py
@@ -95,7 +95,7 @@ def get_operation_log(session_class, deployment_id, operation):
         .options(joinedload(OperationLog.deployment), joinedload("deployment.services"))
         .where(OperationLog.deployment_id == deployment_id)
         .where(OperationLog.operation == operation)
-        .order_by(OperationLog.start)
+        .order_by(OperationLog.start_time)
     )
     with session_class() as session:
         operation_log = session.execute(query).unique().scalar_one_or_none()

--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -15,11 +15,12 @@ class DeploymentLog(Base):
     id = Column(Integer, primary_key=True)
     sources = Column(JSON)
     targets = Column(JSON)
-    filter = Column(String(length=NODE_NAME_MAX_LENGTH))
-    start = Column(DateTime(timezone=False))
-    end = Column(DateTime(timezone=False))
+    filter_expression = Column(String(length=NODE_NAME_MAX_LENGTH))
+    start_time = Column(DateTime(timezone=False))
+    end_time = Column(DateTime(timezone=False))
     state = Column(String(length=StateEnum.max_length()))
+
     operations = relationship(
-        "OperationLog", back_populates="deployment", order_by="OperationLog.start"
+        "OperationLog", back_populates="deployment", order_by="OperationLog.start_time"
     )
     services = relationship("ServiceLog", back_populates="deployment")

--- a/tdp/core/models/operation_log.py
+++ b/tdp/core/models/operation_log.py
@@ -14,8 +14,9 @@ class OperationLog(Base):
 
     deployment_id = Column(Integer, ForeignKey("deployment_log.id"), primary_key=True)
     operation = Column(String(length=NODE_NAME_MAX_LENGTH), primary_key=True)
-    start = Column(DateTime(timezone=False))
-    end = Column(DateTime(timezone=False))
+    start_time = Column(DateTime(timezone=False))
+    end_time = Column(DateTime(timezone=False))
     state = Column(String(length=StateEnum.max_length()))
     logs = Column(LargeBinary)
+
     deployment = relationship("DeploymentLog", back_populates="operations")

--- a/tdp/core/models/service_log.py
+++ b/tdp/core/models/service_log.py
@@ -15,4 +15,5 @@ class ServiceLog(Base):
     deployment_id = Column(Integer, ForeignKey("deployment_log.id"), primary_key=True)
     service = Column(String(length=SERVICE_NAME_MAX_LENGTH), primary_key=True)
     version = Column(String(length=VERSION_MAX_LENGTH), nullable=False)
+
     deployment = relationship("DeploymentLog", back_populates="services")

--- a/tdp/core/runner/operation_runner.py
+++ b/tdp/core/runner/operation_runner.py
@@ -37,7 +37,7 @@ class OperationIterator(Iterator):
             raise e
 
     def fill_deployment_log_at_end(self, state=None):
-        self.deployment_log.end = datetime.utcnow()
+        self.deployment_log.end_time = datetime.utcnow()
         self.deployment_log.state = (
             state if state else self.deployment_log.operations[-1].state
         )
@@ -90,7 +90,11 @@ class OperationRunner:
             state = StateEnum(state)
 
         return OperationLog(
-            operation=operation, start=start, end=end, state=state.value, logs=logs
+            operation=operation,
+            start_time=start,
+            end_time=end,
+            state=state.value,
+            logs=logs,
         )
 
     def _run_operations(self, operation_names, restart=False):
@@ -131,8 +135,8 @@ class OperationRunner:
         deployment_log = DeploymentLog(
             sources=sources,
             targets=targets,
-            filter=str(node_filter) if node_filter else None,
-            start=start,
+            filter_expression=str(node_filter) if node_filter else None,
+            start_time=start,
             state=StateEnum.PENDING.value,
         )
 


### PR DESCRIPTION
fix #207 

This PR replaces attribute names in the SQL schemas not to use reserved standard sql keywords.

The following attributes have been renamed:
- end -> end_time
- filter -> filter_expression
- start -> start_time

The following attributes were not renamed because they are not reserved keyword in the SQL standard:
- operation
- state

Source for reserverd keywords: https://en.wikipedia.org/wiki/SQL_reserved_words