### PR TITLE
fix: raise an error when parameters lead to an empty list of operations

### DIFF
--- a/tdp/cli/commands/deploy.py
+++ b/tdp/cli/commands/deploy.py
@@ -103,9 +103,12 @@ def deploy(
             click.echo(f"Deploying to {targets}")
         else:
             click.echo(f"Deploying TDP")
-        operation_iterator = operation_runner.run_nodes(
-            sources=sources, targets=targets, filter_expression=filter
-        )
+        try:
+            operation_iterator = operation_runner.run_nodes(
+                sources=sources, targets=targets, filter_expression=filter
+            )
+        except ValueError as e:
+            raise click.ClickException(str(e)) from e
         if dry:
             for operation in operation_iterator:
                 pass

--- a/tdp/core/runner/operation_runner.py
+++ b/tdp/core/runner/operation_runner.py
@@ -66,6 +66,10 @@ class OperationIterator(Iterator):
         ]
 
 
+class EmptyOperationPlan(Exception):
+    pass
+
+
 class OperationPlan:
     def __init__(
         self,
@@ -120,7 +124,10 @@ class OperationPlan:
         else:
             str_filter = None
             filter_type = None
-
+        if len(operation_names) == 0:
+            raise EmptyOperationPlan(
+                "Combination of parameters resulted into an empty list of Operations"
+            )
         return OperationPlan(
             operation_names,
             using_dag=True,


### PR DESCRIPTION
fix #216 