### PR TITLE
feat: refactor variables

### DIFF
--- a/docs/developer/core/variables.rst
+++ b/docs/developer/core/variables.rst
@@ -6,11 +6,6 @@ Variables
 
 The :py:class:`~tdp.core.variables.Variables` is used to manage a var file.
 
-VariablesDict
--------------
-
-:py:class:`~tdp.core.variables.VariablesDict` is used to update a var file like a `dict`.
-
 _VariablesIOWrapper
 -------------------
 

--- a/tdp/cli/commands/default_diff.py
+++ b/tdp/cli/commands/default_diff.py
@@ -12,8 +12,8 @@ import click
 from tdp.cli.utils import collection_paths
 from tdp.core.collection import DEFAULT_VARS_DIRECTORY_NAME
 from tdp.core.dag import Dag
-from tdp.core.service_manager import ServiceManager, merge_collection_vars
-from tdp.core.variables import Variables
+from tdp.core.service_manager import ServiceManager
+from tdp.core.variables import Variables, merge_hash
 
 
 @click.command(short_help="Difference between tdp_vars and defaults")
@@ -76,13 +76,13 @@ def service_diff(service):
             continue
         service_varfile = {}
         with Variables(tdp_vars_service_vars_filepath).open() as service_variables:
-            service_varfile = service_variables.to_dict()
+            service_varfile = service_variables.copy()
 
         default_service_varfile = {}
         for default_service_vars_filepath in default_service_vars_filepaths:
             with Variables(default_service_vars_filepath).open() as default_variables:
-                default_service_varfile = merge_collection_vars(
-                    default_service_varfile, default_variables.to_dict()
+                default_service_varfile = merge_hash(
+                    default_service_varfile, default_variables
                 )
 
         service_varfile_content = pprint.pformat(service_varfile).splitlines()

--- a/tdp/core/service_manager.py
+++ b/tdp/core/service_manager.py
@@ -5,21 +5,15 @@ import logging
 from collections import OrderedDict
 from pathlib import Path
 
-from ansible.utils.vars import merge_hash
-
 from tdp.core.collection import YML_EXTENSION
 from tdp.core.operation import Operation
 from tdp.core.repository.git_repository import GitRepository
 from tdp.core.repository.repository import NoVersionYet
-from tdp.core.variables import Variables
+from tdp.core.variables import Variables, merge_hash
 
 logger = logging.getLogger("tdp").getChild("git_repository")
 
 SERVICE_NAME_MAX_LENGTH = 15
-
-
-def merge_collection_vars(dict_a, dict_b):
-    return merge_hash(dict_a, dict_b)
 
 
 class ServiceManager:
@@ -98,9 +92,7 @@ class ServiceManager:
                     merge_result = {}
                     for default_variables_path in default_variables_paths:
                         with Variables(default_variables_path).open() as variables:
-                            merge_result = merge_collection_vars(
-                                merge_result, variables.to_dict()
-                            )
+                            merge_result = merge_hash(merge_result, variables)
 
                     configuration.update(merge_result)
                 # service has no default vars

--- a/tdp/core/test_variables.py
+++ b/tdp/core/test_variables.py
@@ -58,7 +58,7 @@ def test_variables_unset(dummy_inventory):
                 },
             },
         )
-        variables.unset("hdfs_property")
+        del variables["hdfs_property"]
 
     assert "hdfs_property" not in variable_manager.get_vars(
         host=inventory.get_host("master01")
@@ -79,7 +79,7 @@ def test_variables_unset_nested(dummy_inventory):
             },
         )
 
-        variables.unset("hdfs_site.hdfs.nested.property")
+        del variables["hdfs_site"]["hdfs.nested.property"]
 
     assert "hdfs.nested.property" not in variable_manager.get_vars(
         host=inventory.get_host("master01")
@@ -120,12 +120,8 @@ def test_variables_item_is_deletable(dummy_inventory):
                 },
             },
         )
-        del variables["hdfs_site.hdfs.nested.property"]
+        del variables["hdfs_property"]
 
-    assert "hdfs.nested.property" not in variable_manager.get_vars(
+    assert "hdfs_property" not in variable_manager.get_vars(
         host=inventory.get_host("master01")
-    ).get("hdfs_site")
-
-    assert "another_value" == variable_manager.get_vars(
-        host=inventory.get_host("master01")
-    ).get("hdfs_site").get("hdfs.another.nested.property")
+    )


### PR DESCRIPTION
fix #223

Simplification of variables handling.

Returning deepcopy on get was a bad idea, and made handling vars very unpythonic.

`_flush_on_write` was utopic because it wasn't called on inner dict, or if the key's value was another kind of container (append on a list).

It's easier and more sound to flush when closing. Relying on caller either using the `Variables.open()` values into a context manager, or calling `close()` himself.