### PR TITLE
fix(model): introduce surrogate key in ServiceComponentLog

### DIFF
--- a/tdp/core/models/service_component_log.py
+++ b/tdp/core/models/service_component_log.py
@@ -1,7 +1,7 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from tdp.core.models.base import Base
@@ -12,13 +12,12 @@ from tdp.core.repository.repository import VERSION_MAX_LENGTH
 class ServiceComponentLog(Base):
     __tablename__ = "service_component_log"
 
-    deployment_id = Column(Integer, ForeignKey("deployment_log.id"), primary_key=True)
-    service = Column(
-        String(length=SERVICE_NAME_MAX_LENGTH), primary_key=True, nullable=False
-    )
-    component = Column(
-        String(length=COMPONENT_NAME_MAX_LENGTH), primary_key=True, nullable=True
-    )
+    id = Column(Integer, primary_key=True)
+    deployment_id = Column(Integer, ForeignKey("deployment_log.id"), nullable=False)
+    service = Column(String(length=SERVICE_NAME_MAX_LENGTH), nullable=False)
+    component = Column(String(length=COMPONENT_NAME_MAX_LENGTH), nullable=True)
     version = Column(String(length=VERSION_MAX_LENGTH), nullable=False)
 
     deployment = relationship("DeploymentLog", back_populates="service_components")
+
+    __table_args__ = (UniqueConstraint("deployment_id", "service", "component"),)


### PR DESCRIPTION
<!--  Thank you for sending a pull request! Please make sure:

1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes:
<!--
Example: "Fixes #(issue number)" or "Fixes (link of issue)".
-->
Fixes #273

#### Additional comments:
<!--
Example: `"I was not sure if it is the right way to do but..."
-->

Having part of a composite primary key nullable is forbidden in Postgresql, therefore we needed to introduce a surrogate key to become the new primary key.

#### Agreements

To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to [TOSIT](https://www.tosit.io/), you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
 - [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
