### PR TITLE
feat(cli/init): allow multiple overrides paths

### DIFF
--- a/tdp/cli/commands/init.py
+++ b/tdp/cli/commands/init.py
@@ -16,7 +16,8 @@ from tdp.core.variables import ClusterVariables
     envvar="TDP_OVERRIDES",
     required=False,
     type=click.Path(exists=True, resolve_path=True, path_type=Path),
-    help="Path to tdp vars overrides",
+    multiple=True,
+    help="Path to tdp vars overrides. Can be used multiple times. Last one takes precedence.",
 )
 @collections
 @database_dsn

--- a/tdp/core/variables/cluster_variables.py
+++ b/tdp/core/variables/cluster_variables.py
@@ -30,7 +30,7 @@ class ClusterVariables(Mapping):
     def initialize_cluster_variables(
         collections,
         tdp_vars,
-        override_folder=None,
+        override_folders=None,
         repository_class=GitRepository,
         validate=False,
     ):
@@ -39,11 +39,14 @@ class ClusterVariables(Mapping):
         Args:
             collections (Collections): instance of collections
             tdp_vars (Union[str, Path]): path to the tdp vars
-            override_folder (Optional[str | Path]): path of tdp vars overrides
+            override_folders (Iterable[str | Path]): list of path(s) of tdp vars overrides
 
         Returns:
             ClusterVariables: mapping of service with their ServiceVariables instance
         """
+        if override_folders is None:
+            override_folders = []
+        
         tdp_vars = Path(tdp_vars)
 
         cluster_variables = {}
@@ -52,9 +55,12 @@ class ClusterVariables(Mapping):
             (collection_name, collection.default_vars_directory.iterdir())
             for collection_name, collection in collections.items()
         ]
-        if override_folder:
+
+        for i, override_folder in enumerate(override_folders):
             override_folder = Path(override_folder)
-            collections_and_overrides.append(("overrides", override_folder.iterdir()))
+            collections_and_overrides.append(
+                (f"overrides_path_{i}", override_folder.iterdir())
+            )
 
         # If the service was already initialized, we do not touch it
         services_initialized_by_this_function = set()


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #301 

#### Additional comments
Here is a proposal for the linked issue to provide multiple paths. Those changes rely on Click's `multiple=True` option for command line options.
##### Usage
There are two ways to provide multiple paths :
- multiple `--overrides` from CLI :
```bash
tdp init --overrides my_vars/platform1 --overrides my_vars/dev
```
- multiple overrides paths from `TDP_OVERRIDES` environment variable :
```bash
export TDP_OVERRIDES=my_vars/platform1:my_vars/dev
tdp init
```
Both give the same output
```
2023-03-06 17:34:43,936 - INFO - tdp.cluster_variables.initialize_cluster_variables - hadoop is already initialized at 5f0a6bbb62d169c95d8c8079a989fd4200bcd04c
2023-03-06 17:34:43,942 - INFO - tdp.service_variables.update_from_variables_folder - Updating hadoop with variables from /my_env/my_vars/platform1/hadoop/hadoop.yml
2023-03-06 17:34:43,950 - DEBUG - tdp.git_repository.add_for_validation - hadoop.yml staged
2023-03-06 17:34:43,969 - INFO - tdp.git_repository.validate - commit: [8698ef55295c99d278e35420f8bd3888c5f75314] add variables from overrides_option_0
2023-03-06 17:34:43,969 - INFO - tdp.cluster_variables.initialize_cluster_variables - hadoop is already initialized at 8698ef55295c99d278e35420f8bd3888c5f75314
2023-03-06 17:34:43,975 - INFO - tdp.service_variables.update_from_variables_folder - Updating hadoop with variables from /my_env/my_vars/dev/hadoop/hadoop.yml
2023-03-06 17:34:43,980 - DEBUG - tdp.git_repository.add_for_validation - hadoop.yml staged
2023-03-06 17:34:43,999 - INFO - tdp.git_repository.validate - commit: [56f6512e8cc0ad7b87ebb9b38dc8fa3d2dd7ab56] add variables from overrides_option_1
```
##### Tests
- providing one path still works
- if both `--overrides` from CLI and environment variable `TDP_OVERRIDES` are used at the same time, only `--overrides` CLI options will be used and `TDP_OVERRIDES` will be ignored (`click`'s behavior)
- providing tdp overrides paths (NO `--overrides` CLI option and NO `TDP_OVERRIDES`) still works
- `poetry run pytest tdp` passed

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
