### PR TITLE
refactor: rename ServiceComponentLog to ComponentVersionLog

### DIFF
--- a/docs/source/tdp.core.models.rst
+++ b/docs/source/tdp.core.models.rst
@@ -36,7 +36,7 @@ tdp.core.models.operation\_log module
 tdp.core.models.service\_component\_log module
 ----------------------------------------------
 
-.. automodule:: tdp.core.models.service_component_log
+.. automodule:: tdp.core.models.component_version_log
    :members:
    :undoc-members:
    :show-inheritance:

--- a/tdp/cli/commands/deploy.py
+++ b/tdp/cli/commands/deploy.py
@@ -72,11 +72,11 @@ def deploy(
             # Update deployment log to RUNNING
             session.merge(deployment_iterator.deployment_log)
             session.commit()
-            for operation_log, service_component_log in deployment_iterator:
+            for operation_log, component_version_log in deployment_iterator:
                 if operation_log is not None:
                     session.merge(operation_log)
-                if service_component_log is not None:
-                    session.add(service_component_log)
+                if component_version_log is not None:
+                    session.add(component_version_log)
                 session.commit()
             # Update deployment log to SUCCESS or FAILURE
             session.merge(deployment_iterator.deployment_log)

--- a/tdp/cli/commands/plan/reconfigure.py
+++ b/tdp/cli/commands/plan/reconfigure.py
@@ -3,7 +3,7 @@
 
 import click
 
-from tdp.cli.queries import get_latest_success_service_component_version_query
+from tdp.cli.queries import get_latest_success_component_version_log
 from tdp.cli.session import get_session_class
 from tdp.cli.utils import (
     check_services_cleanliness,
@@ -40,11 +40,11 @@ def reconfigure(
 
     session_class = get_session_class(database_dsn)
     with session_class() as session:
-        latest_success_service_component_version = (
-            get_latest_success_service_component_version_query(session)
+        latest_success_component_version_log = (
+            get_latest_success_component_version_log(session)
         )
-        service_component_deployed_version = map(
-            lambda result: result[1:], latest_success_service_component_version
+        latest_success_component_version = map(
+            lambda result: result[1:], latest_success_component_version_log
         )
         cluster_variables = ClusterVariables.get_cluster_variables(
             collections, vars, validate=validate
@@ -54,7 +54,7 @@ def reconfigure(
         try:
             click.echo(f"Creating a deployment plan to reconfigure services.")
             deployment_log = DeploymentPlan.from_reconfigure(
-                dag, cluster_variables, service_component_deployed_version
+                dag, cluster_variables, latest_success_component_version
             ).deployment_log
         except NothingToRestartError:
             click.echo("Nothing needs to be restarted.")

--- a/tdp/cli/commands/service_versions.py
+++ b/tdp/cli/commands/service_versions.py
@@ -4,10 +4,10 @@
 import click
 from tabulate import tabulate
 
-from tdp.cli.queries import get_latest_success_service_component_version_query
+from tdp.cli.queries import get_latest_success_component_version_log
 from tdp.cli.session import get_session_class
 from tdp.cli.utils import database_dsn
-from tdp.core.models import ServiceComponentLog
+from tdp.core.models import ComponentVersionLog
 
 
 @click.command(
@@ -22,7 +22,7 @@ def service_versions(database_dsn):
 
     with session_class() as session:
         latest_success_service_version = (
-            get_latest_success_service_component_version_query(session)
+            get_latest_success_component_version_log(session)
         )
 
         click.echo(
@@ -30,10 +30,10 @@ def service_versions(database_dsn):
             + tabulate(
                 latest_success_service_version,
                 headers=[
-                    ServiceComponentLog.deployment_id.name,
-                    ServiceComponentLog.service.name,
-                    ServiceComponentLog.component.name,
-                    ServiceComponentLog.version.name,
+                    ComponentVersionLog.deployment_id.name,
+                    ComponentVersionLog.service.name,
+                    ComponentVersionLog.component.name,
+                    ComponentVersionLog.version.name,
                 ],
             )
         )

--- a/tdp/core/deployment/conftest.py
+++ b/tdp/core/deployment/conftest.py
@@ -67,7 +67,7 @@ def reconfigurable_cluster_variables(
     cluster_variables = ClusterVariables.initialize_cluster_variables(
         minimal_collections, tdp_vars
     )
-    service_component_deployed_version = [
+    latest_success_component_version = [
         ("mock", None, cluster_variables["mock"].version),
         ("mock", "node", cluster_variables["mock"].version),
     ]
@@ -76,7 +76,7 @@ def reconfigurable_cluster_variables(
         "update service configuration", ["mock.yml"]
     ) as configuration:
         configuration["mock.yml"].merge({"test": 1})
-    return (cluster_variables, service_component_deployed_version)
+    return (cluster_variables, latest_success_component_version)
 
 
 @pytest.fixture(scope="session")

--- a/tdp/core/deployment/deployment_iterator.py
+++ b/tdp/core/deployment/deployment_iterator.py
@@ -11,7 +11,7 @@ from tdp.core.models import (
     DeploymentStateEnum,
     OperationLog,
     OperationStateEnum,
-    ServiceComponentLog,
+    ComponentVersionLog,
 )
 from tdp.core.operation import Operation
 from tdp.core.variables import ClusterVariables
@@ -63,7 +63,7 @@ class DeploymentIterator(Iterator):
         self._iter = iter(operations_with_operation_logs)
         self._component_states = defaultdict(_Flags)
 
-    def __next__(self) -> Tuple[OperationLog, ServiceComponentLog]:
+    def __next__(self) -> Tuple[OperationLog, ComponentVersionLog]:
         try:
             while True:
                 (operation, operation_log) = next(self._iter)
@@ -84,15 +84,15 @@ class DeploymentIterator(Iterator):
                     and component_state.is_configured == True
                     and component_state.is_started == False
                 ):
-                    service_component_log = ServiceComponentLog(
+                    component_version_log = ComponentVersionLog(
                         service=operation.service_name,
                         component=operation.component_name,
                         version=self._cluster_variables[operation.service_name].version,
                     )
-                    service_component_log.deployment = self.deployment_log
+                    component_version_log.deployment = self.deployment_log
                     component_state.is_started = True
                 else:
-                    service_component_log = None
+                    component_version_log = None
 
                 if operation.noop == False:
                     result = self._run_operation(operation)
@@ -106,7 +106,7 @@ class DeploymentIterator(Iterator):
                 else:
                     operation_log.state = OperationStateEnum.SUCCESS
 
-                return operation_log, service_component_log
+                return operation_log, component_version_log
         # StopIteration is a "normal" exception raised when the iteration has stopped
         except StopIteration as e:
             self.deployment_log.end_time = datetime.utcnow()

--- a/tdp/core/deployment/deployment_plan.py
+++ b/tdp/core/deployment/deployment_plan.py
@@ -12,7 +12,7 @@ from tdp.core.models import (
     FilterTypeEnum,
     OperationLog,
     OperationStateEnum,
-    ServiceComponentLog,
+    ComponentVersionLog,
 )
 from tdp.core.operation import Operation
 from tdp.core.variables import ClusterVariables
@@ -134,14 +134,14 @@ class DeploymentPlan:
     def from_reconfigure(
         dag: Dag,
         cluster_variables: ClusterVariables,
-        service_component_deployed_version: ServiceComponentLog,
+        component_version_deployed: ComponentVersionLog,
     ) -> "DeploymentPlan":
-        """Generate a deployment plan from a list of service component deployed version.
+        """Generate a deployment plan based on altered component configuration.
 
         Args:
             dag: DAG to generate the deployment plan from.
             cluster_variables: Cluster variables.
-            service_component_deployed_version: List of deployed versions.
+            component_version_deployed: List of deployed versions.
 
         Raises:
             RuntimeError: If a service is deployed but the repository is missing.
@@ -154,7 +154,7 @@ class DeploymentPlan:
             service,
             _component,
             version,
-        ) in service_component_deployed_version:
+        ) in component_version_deployed:
             if service not in cluster_variables:
                 raise RuntimeError(
                     f"Service '{service}' is deployed but the repository is missing."

--- a/tdp/core/deployment/test_deployment_plan.py
+++ b/tdp/core/deployment/test_deployment_plan.py
@@ -185,10 +185,10 @@ def test_deployment_plan_reconfigure_nothing_to_restart(dag, cluster_variables):
 def test_deployment_plan_reconfigure(dag, reconfigurable_cluster_variables):
     (
         cluster_variables,
-        service_component_deployed_version,
+        component_version_deployed,
     ) = reconfigurable_cluster_variables
     deployment_plan = DeploymentPlan.from_reconfigure(
-        dag, cluster_variables, service_component_deployed_version
+        dag, cluster_variables, component_version_deployed
     )
 
     assert len(deployment_plan.operations) == 4

--- a/tdp/core/deployment/test_deployment_runner.py
+++ b/tdp/core/deployment/test_deployment_runner.py
@@ -50,7 +50,7 @@ def test_deployment_plan_is_success(dag, deployment_runner):
 
     assert deployment_iterator.deployment_log.state == DeploymentStateEnum.SUCCESS
     assert len(deployment_iterator.deployment_log.operations) == 8
-    assert len(deployment_iterator.deployment_log.service_components) == 2
+    assert len(deployment_iterator.deployment_log.component_version) == 2
 
 
 def test_deployment_plan_with_filter_is_success(dag, deployment_runner):
@@ -103,7 +103,7 @@ def test_service_log_is_emitted(dag, deployment_runner):
         pass
 
     assert deployment_iterator.deployment_log.state == DeploymentStateEnum.SUCCESS
-    assert len(deployment_iterator.deployment_log.service_components) == 2
+    assert len(deployment_iterator.deployment_log.component_version) == 2
 
 
 def test_service_log_is_not_emitted(dag, deployment_runner):
@@ -117,7 +117,7 @@ def test_service_log_is_not_emitted(dag, deployment_runner):
         pass
 
     assert deployment_iterator.deployment_log.state == DeploymentStateEnum.SUCCESS
-    assert len(deployment_iterator.deployment_log.service_components) == 0
+    assert len(deployment_iterator.deployment_log.component_version) == 0
 
 
 def test_service_log_only_noop_is_emitted(minimal_collections, deployment_runner):
@@ -134,7 +134,7 @@ def test_service_log_only_noop_is_emitted(minimal_collections, deployment_runner
         pass
 
     assert deployment_iterator.deployment_log.state == DeploymentStateEnum.SUCCESS
-    assert len(deployment_iterator.deployment_log.service_components) == 1
+    assert len(deployment_iterator.deployment_log.component_version) == 1
 
 
 def test_service_log_not_emitted_when_config_start_wrong_order(
@@ -153,7 +153,7 @@ def test_service_log_not_emitted_when_config_start_wrong_order(
         pass
 
     assert deployment_iterator.deployment_log.state == DeploymentStateEnum.SUCCESS
-    assert len(deployment_iterator.deployment_log.service_components) == 0
+    assert len(deployment_iterator.deployment_log.component_version) == 0
 
 
 def test_service_log_emitted_once_with_start_and_restart(
@@ -173,7 +173,7 @@ def test_service_log_emitted_once_with_start_and_restart(
         pass
 
     assert deployment_iterator.deployment_log.state == DeploymentStateEnum.SUCCESS
-    assert len(deployment_iterator.deployment_log.service_components) == 1
+    assert len(deployment_iterator.deployment_log.component_version) == 1
 
 
 def test_service_log_emitted_once_with_multiple_config_and_start_on_same_component(
@@ -194,7 +194,7 @@ def test_service_log_emitted_once_with_multiple_config_and_start_on_same_compone
         pass
 
     assert deployment_iterator.deployment_log.state == DeploymentStateEnum.SUCCESS
-    assert len(deployment_iterator.deployment_log.service_components) == 1
+    assert len(deployment_iterator.deployment_log.component_version) == 1
 
 
 def test_deployment_is_resumed(dag, failing_deployment_runner, deployment_runner):
@@ -225,11 +225,11 @@ def test_deployment_is_reconfigured(
 ):
     (
         cluster_variables,
-        service_component_deployed_version,
+        component_version_deployed,
     ) = reconfigurable_cluster_variables
 
     deployment_plan = DeploymentPlan.from_reconfigure(
-        dag, cluster_variables, service_component_deployed_version
+        dag, cluster_variables, component_version_deployed
     )
     deployment_iterator = deployment_runner.run(deployment_plan)
     for _ in deployment_iterator:
@@ -243,11 +243,11 @@ def test_deployment_reconfigure_is_resumed(
 ):
     (
         cluster_variables,
-        service_component_deployed_version,
+        component_version_deployed,
     ) = reconfigurable_cluster_variables
 
     deployment_plan = DeploymentPlan.from_reconfigure(
-        dag, cluster_variables, service_component_deployed_version
+        dag, cluster_variables, component_version_deployed
     )
     deployment_iterator = failing_deployment_runner.run(deployment_plan)
 

--- a/tdp/core/models/__init__.py
+++ b/tdp/core/models/__init__.py
@@ -4,7 +4,7 @@
 from .base import Base
 from .deployment_log import DeploymentLog, DeploymentTypeEnum, FilterTypeEnum
 from .operation_log import OperationLog
-from .service_component_log import ServiceComponentLog
+from .component_version_log import ComponentVersionLog
 from .state_enum import DeploymentStateEnum, OperationStateEnum
 
 

--- a/tdp/core/models/component_version_log.py
+++ b/tdp/core/models/component_version_log.py
@@ -9,20 +9,18 @@ from tdp.core.operation import COMPONENT_NAME_MAX_LENGTH, SERVICE_NAME_MAX_LENGT
 from tdp.core.repository.repository import VERSION_MAX_LENGTH
 
 
-class ServiceComponentLog(Base):
-    """Component log model.
-
-    Hold what component version is deployed.
+class ComponentVersionLog(Base):
+    """Hold what component version are deployed.
 
     Attributes:
-        id (int): Service component log id.
+        id (int): Component version log id.
         deployment_id (int): Deployment log id.
         service (str): Service name.
         component (str): Component name.
         version (str): Component version.
     """
 
-    __tablename__ = "service_component_log"
+    __tablename__ = "component_version_log"
 
     id = Column(Integer, primary_key=True)
     deployment_id = Column(Integer, ForeignKey("deployment_log.id"), nullable=False)
@@ -30,6 +28,6 @@ class ServiceComponentLog(Base):
     component = Column(String(length=COMPONENT_NAME_MAX_LENGTH), nullable=True)
     version = Column(String(length=VERSION_MAX_LENGTH), nullable=False)
 
-    deployment = relationship("DeploymentLog", back_populates="service_components")
+    deployment = relationship("DeploymentLog", back_populates="component_version")
 
     __table_args__ = (UniqueConstraint("deployment_id", "service", "component"),)

--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -77,6 +77,6 @@ class DeploymentLog(Base):
         order_by="OperationLog.start_time",
         cascade="all, delete-orphan",
     )
-    service_components = relationship(
-        "ServiceComponentLog", back_populates="deployment"
+    component_version = relationship(
+        "ComponentVersionLog", back_populates="deployment"
     )

--- a/tdp/core/models/test_db.py
+++ b/tdp/core/models/test_db.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import sessionmaker
 from .base import Base
 from .deployment_log import DeploymentLog
 from .operation_log import OperationLog
-from .service_component_log import ServiceComponentLog
+from .component_version_log import ComponentVersionLog
 
 logger = logging.getLogger("tdp").getChild("test_db")
 
@@ -49,7 +49,7 @@ def test_create_deployment_log(session_maker: sessionmaker):
         deployment_type="Dag",
         restart=False,
     )
-    service_component_log = ServiceComponentLog(
+    component_version_log = ComponentVersionLog(
         deployment_id=deployment_log.id,
         service="service1",
         component="component1",
@@ -65,7 +65,7 @@ def test_create_deployment_log(session_maker: sessionmaker):
         logs=b"operation log",
     )
 
-    deployment_log.service_components.append(service_component_log)
+    deployment_log.component_version.append(component_version_log)
     deployment_log.operations.append(operation_log)
 
     logger.info(deployment_log)
@@ -80,7 +80,7 @@ def test_create_deployment_log(session_maker: sessionmaker):
 
         logger.info(result)
         logger.info(result.operations)
-        logger.info(result.service_components)
+        logger.info(result.component_version)
 
         assert result is not None
         assert result.sources == ["source1", "source2"]
@@ -91,10 +91,10 @@ def test_create_deployment_log(session_maker: sessionmaker):
         assert result.deployment_type == "Dag"
         assert result.restart is False
 
-        assert len(result.service_components) == 1
-        assert result.service_components[0].service == "service1"
-        assert result.service_components[0].component == "component1"
-        assert result.service_components[0].version == "1.0.0"
+        assert len(result.component_version) == 1
+        assert result.component_version[0].service == "service1"
+        assert result.component_version[0].component == "component1"
+        assert result.component_version[0].version == "1.0.0"
 
         assert len(result.operations) == 1
         assert result.operations[0].operation_order == 1


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Part of #348 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Rename the `service_component_log` table to `component_version_log` and rename related variables accordingly.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
