### PR TITLE
refactor: collection methods

### DIFF
--- a/tdp/conftest.py
+++ b/tdp/conftest.py
@@ -9,7 +9,7 @@ import yaml
 from tdp.core.collection import (
     DAG_DIRECTORY_NAME,
     DEFAULT_VARS_DIRECTORY_NAME,
-    OPERATION_DIRECTORY_NAME,
+    PLAYBOOKS_DIRECTORY_NAME,
     SCHEMA_VARS_DIRECTORY_NAME,
 )
 
@@ -20,7 +20,7 @@ def generate_collection(
     service_vars: Mapping[str, Mapping[str, dict]],
 ):
     tdp_lib_dag = directory / DAG_DIRECTORY_NAME
-    playbooks = directory / OPERATION_DIRECTORY_NAME
+    playbooks = directory / PLAYBOOKS_DIRECTORY_NAME
     tdp_vars_defaults = directory / DEFAULT_VARS_DIRECTORY_NAME
     tdp_vars_schema = directory / SCHEMA_VARS_DIRECTORY_NAME
 

--- a/tdp/core/collections.py
+++ b/tdp/core/collections.py
@@ -128,7 +128,7 @@ class Collections(Mapping):
 
         # Init Operations not in the DAG
         for collection_name, collection in self._collections.items():
-            for operation_name, _ in collection.operations.items():
+            for operation_name, _ in collection.playbooks.items():
                 if operation_name in self._dag_operations:
                     continue
                 if operation_name in self._other_operations:

--- a/tdp/core/dag.py
+++ b/tdp/core/dag.py
@@ -330,10 +330,7 @@ class Dag:
 
             # Operations tagged with the noop flag should not have a playbook defined in the collection
 
-            if (
-                operation_name
-                in self._collections[operation.collection_name].operations
-            ):
+            if operation_name in self._collections[operation.collection_name].playbooks:
                 if operation.noop:
                     c_warning(
                         f"Operation '{operation_name}' is noop and the playbook should not exist"

--- a/tdp/core/deployment/deployment_runner.py
+++ b/tdp/core/deployment/deployment_runner.py
@@ -53,7 +53,7 @@ class DeploymentRunner:
 
         start = datetime.utcnow()
 
-        operation_file = self._collections[operation.collection_name].operations[
+        operation_file = self._collections[operation.collection_name].playbooks[
             operation.name
         ]
         state, logs = self._executor.execute(operation_file)

--- a/tdp/core/test_collection.py
+++ b/tdp/core/test_collection.py
@@ -47,5 +47,5 @@ def test_collection_from_path(tmp_path_factory: pytest.TempPathFactory):
     generate_collection(collection_path, dag_service_operations, service_vars)
     collection = Collection.from_path(collection_path)
     assert collection_path / DAG_DIRECTORY_NAME / "service.yml" in collection.dag_yamls
-    assert "service_install" in collection.operations
-    assert "service_config" in collection.operations
+    assert "service_install" in collection.playbooks
+    assert "service_config" in collection.playbooks


### PR DESCRIPTION
Remove unused methods from collection class.
Rename operations to playbooks to avoid confusion.

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Refactor the `Collection` class:

- Remove unused properties (most of the paths are only used internally). Create a `_get_directory` method to handle the retrieval of dir without these properties.
- Rename "operations" to "playbooks" to better describe the objects in this context.
- Remove the `from_path` static method as it don't bring much (it takes the same parameters as `__init__`). The tests have been moved into their own method (it should make unit testing easier).

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
