### PR TITLE
374 check if operation exist at deployment plan creation

### DIFF
--- a/tdp/cli/commands/plan/run.py
+++ b/tdp/cli/commands/plan/run.py
@@ -24,24 +24,13 @@ def run(
 ):
     if not vars.exists():
         raise click.BadParameter(f"{vars} does not exist.")
-    dag = Dag(collections)
-
-    operations = []
-    for operation_name in operation_names:
-        operation = dag.collections.operations.get(operation_name, None)
-        if not operation:
-            raise click.BadParameter(f"{operation_name} is not a valid operation.")
-
-        if operation.noop:
-            raise click.BadParameter(
-                f"{operation_name} is tagged as noop and thus"
-                " cannot be executed in an unitary deployment."
-            )
-        operations.append(operation)
-
-    click.echo(f"Creating a deployment plan to run {len(operations)} operation(s).")
+    click.echo(
+        f"Creating a deployment plan to run {len(operation_names)} operation(s)."
+    )
     try:
-        deployment_log = DeploymentPlan.from_operations(operations).deployment_log
+        deployment_log = DeploymentPlan.from_operations(
+            collections, operation_names
+        ).deployment_log
     except Exception as e:
         raise click.ClickException(str(e)) from e
 

--- a/tdp/conftest.py
+++ b/tdp/conftest.py
@@ -35,7 +35,7 @@ def generate_collection(
             yaml.dump(operations, fd)
 
         for operation in operations:
-            if operation["name"].endswith("_start"):
+            if operation["name"].endswith("_start") and "noop" not in operation:
                 with (
                     playbooks / (operation["name"].rstrip("_start") + "_restart.yml")
                 ).open("w") as fd:

--- a/tdp/core/collections.py
+++ b/tdp/core/collections.py
@@ -219,5 +219,7 @@ class Collections(Mapping):
             The Operation instance.
         """
         if operation_name not in self.operations:
-            raise MissingOperationError(f"Operation {operation_name} not found in collections.")
+            raise MissingOperationError(
+                f"Operation {operation_name} not found in collections."
+            )
         return self.operations[operation_name]

--- a/tdp/core/collections.py
+++ b/tdp/core/collections.py
@@ -21,6 +21,10 @@ except ImportError:
 logger = logging.getLogger("tdp").getChild("collections")
 
 
+class MissingOperationError(Exception):
+    pass
+
+
 class Collections(Mapping):
     """A mapping of collection name to Collection instance.
 
@@ -215,5 +219,5 @@ class Collections(Mapping):
             The Operation instance.
         """
         if operation_name not in self.operations:
-            raise ValueError(f"Operation {operation_name} not found in collections.")
+            raise MissingOperationError(f"Operation {operation_name} not found in collections.")
         return self.operations[operation_name]

--- a/tdp/core/dag.py
+++ b/tdp/core/dag.py
@@ -39,10 +39,6 @@ SERVICE_PRIORITY = {
 DEFAULT_SERVICE_PRIORITY = 99
 
 
-class MissingOperationError(Exception):
-    pass
-
-
 class IllegalNodeError(Exception):
     pass
 
@@ -176,10 +172,7 @@ class Dag:
             return f"{operation_priority:02d}_{node}"
 
         def to_operation(node: str) -> Operation:
-            try:
-                operation = self.collections.operations[node]
-            except KeyError as e:
-                raise MissingOperationError(f"{node} is missing an operation") from e
+            operation = self.collections.get_operation(node)
             if restart:
                 if node.endswith("_start"):
                     node = node.replace("_start", "_restart")
@@ -191,12 +184,7 @@ class Dag:
                             noop=True,
                             depends_on=operation.depends_on,
                         )
-                try:
-                    return self.collections.operations[node]
-                except KeyError as e:
-                    raise MissingOperationError(
-                        f"{node} is missing an operation"
-                    ) from e
+                return self.collections.get_operation(node)
             return operation
 
         return list(

--- a/tdp/core/deployment/deployment_plan.py
+++ b/tdp/core/deployment/deployment_plan.py
@@ -138,14 +138,10 @@ class DeploymentPlan:
             UnsupportedOperationError: If an operation is a noop.
             ValueError: If an operation is not found in the collections.
         """
-        operations = []
-        for operation_name in operation_names:
-            operation = collections.get_operation(operation_name)
-            if operation.noop:
-                raise UnsupportedOperationError(
-                    f"Operation {operation.name} is a noop and cannot be executed in an unitary deployment."
-                )
-            operations.append(operation)
+        operations = [
+            collections.get_operation(operation_name)
+            for operation_name in operation_names
+        ]
 
         deployment_log = DeploymentLog(
             targets=operation_names,

--- a/tdp/core/deployment/test_deployment_plan.py
+++ b/tdp/core/deployment/test_deployment_plan.py
@@ -81,13 +81,45 @@ class TestFromOperations:
 
     def test_single_noop_opeation(self, minimal_collections: Collections):
         operations_names = ["mock_config"]
-        with pytest.raises(UnsupportedOperationError):
-            DeploymentPlan.from_operations(minimal_collections, operations_names)
+        deployment_plan = DeploymentPlan.from_operations(
+            minimal_collections, operations_names
+        )
+
+        assert deployment_plan.operations == [
+            minimal_collections.get_operation(operations_names[0])
+        ]
+        assert (
+            deployment_plan.deployment_log.deployment_type
+            == DeploymentTypeEnum.OPERATIONS
+        )
+        assert deployment_plan.deployment_log.targets == operations_names
+        assert deployment_plan.deployment_log.sources == None
+        assert deployment_plan.deployment_log.filter_expression == None
+        assert deployment_plan.deployment_log.filter_type == None
+        assert (
+            deployment_plan.deployment_log.restart == None
+        )  # restart flag is only used in dag
 
     def test_single_restart_noop_operation(self, minimal_collections: Collections):
         operations_names = ["mock_restart"]
-        with pytest.raises(UnsupportedOperationError):
-            DeploymentPlan.from_operations(minimal_collections, operations_names)
+        deployment_plan = DeploymentPlan.from_operations(
+            minimal_collections, operations_names
+        )
+
+        assert deployment_plan.operations == [
+            minimal_collections.get_operation(operations_names[0])
+        ]
+        assert (
+            deployment_plan.deployment_log.deployment_type
+            == DeploymentTypeEnum.OPERATIONS
+        )
+        assert deployment_plan.deployment_log.targets == operations_names
+        assert deployment_plan.deployment_log.sources == None
+        assert deployment_plan.deployment_log.filter_expression == None
+        assert deployment_plan.deployment_log.filter_type == None
+        assert (
+            deployment_plan.deployment_log.restart == None
+        )  # restart flag is only used in dag
 
     def test_multiple_operations(self, minimal_collections: Collections):
         operations_names = ["mock_node_config", "mock_node_restart"]

--- a/tdp/core/deployment/test_deployment_runner.py
+++ b/tdp/core/deployment/test_deployment_runner.py
@@ -69,9 +69,7 @@ def test_deployment_plan_with_filter_is_success(dag, deployment_runner):
 
 def test_noop_deployment_plan_is_success(minimal_collections, deployment_runner):
     """deployment plan containing only noop operation"""
-    deployment_plan = DeploymentPlan.from_operations(
-        [minimal_collections.operations["mock_init"]]
-    )
+    deployment_plan = DeploymentPlan.from_operations(minimal_collections, ["mock_init"])
     deployment_iterator = deployment_runner.run(deployment_plan)
 
     for operation, _ in deployment_iterator:
@@ -122,10 +120,7 @@ def test_service_log_is_not_emitted(dag, deployment_runner):
 def test_service_log_only_noop_is_emitted(minimal_collections, deployment_runner):
     """deployment plan containing only noop config and start"""
     deployment_plan = DeploymentPlan.from_operations(
-        [
-            minimal_collections.operations["mock_config"],
-            minimal_collections.operations["mock_start"],
-        ]
+        minimal_collections, ["mock_config", "mock_start"]
     )
     deployment_iterator = deployment_runner.run(deployment_plan)
 
@@ -141,10 +136,7 @@ def test_service_log_not_emitted_when_config_start_wrong_order(
 ):
     """deployment plan containing start then config should not emit service log"""
     deployment_plan = DeploymentPlan.from_operations(
-        [
-            minimal_collections.operations["mock_node_start"],
-            minimal_collections.operations["mock_node_config"],
-        ]
+        minimal_collections, ["mock_node_start", "mock_node_config"]
     )
     deployment_iterator = deployment_runner.run(deployment_plan)
 
@@ -160,11 +152,8 @@ def test_service_log_emitted_once_with_start_and_restart(
 ):
     """deployment plan containing config, start, and restart should emit only one service log"""
     deployment_plan = DeploymentPlan.from_operations(
-        [
-            minimal_collections.operations["mock_node_config"],
-            minimal_collections.operations["mock_node_start"],
-            minimal_collections.operations["mock_node_restart"],
-        ]
+        minimal_collections,
+        ["mock_node_config", "mock_node_start", "mock_node_restart"],
     )
     deployment_iterator = deployment_runner.run(deployment_plan)
 
@@ -180,12 +169,13 @@ def test_service_log_emitted_once_with_multiple_config_and_start_on_same_compone
 ):
     """deployment plan containing multiple config, start, and restart should emit only one service log"""
     deployment_plan = DeploymentPlan.from_operations(
+        minimal_collections,
         [
-            minimal_collections.operations["mock_node_config"],
-            minimal_collections.operations["mock_node_start"],
-            minimal_collections.operations["mock_node_config"],
-            minimal_collections.operations["mock_node_restart"],
-        ]
+            "mock_node_config",
+            "mock_node_start",
+            "mock_node_config",
+            "mock_node_restart",
+        ],
     )
     deployment_iterator = deployment_runner.run(deployment_plan)
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #374
Fixes #357

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

I moved the logic checking if operations exist from cli `run` command to core `DeploymentPlan.from_operations`. 2 tests are still failing because they are using the DeploymentPlan.from_operations to test the DeploymentRunner with noop operations (which is not possible anymore). This raises some questions:

- Should we allow the `tdp plan run` command to take noop operations as arguments? If yes, this could lead to "empty" deployment, nothing will be executed.
- Should we keep those tests?

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
