### PR TITLE
feat: reconfigure uses stale components

### DIFF
--- a/tdp/cli/commands/plan/reconfigure.py
+++ b/tdp/cli/commands/plan/reconfigure.py
@@ -4,54 +4,34 @@
 import click
 
 from tdp.cli.queries import (
-    get_latest_success_component_version_log,
+    get_stale_components,
     get_planned_deployment_log,
 )
 from tdp.cli.session import get_session_class
 from tdp.cli.utils import (
-    check_services_cleanliness,
     collections,
     database_dsn,
-    validate,
-    vars,
 )
-from tdp.core.dag import Dag
 from tdp.core.models import DeploymentLog
-from tdp.core.variables import ClusterVariables
 
 
 @click.command(short_help="Restart required TDP services.")
 @collections
 @database_dsn
-@validate
-@vars
 def reconfigure(
     collections,
     database_dsn,
-    validate,
-    vars,
 ):
-    if not vars.exists():
-        raise click.BadParameter(f"{vars} does not exist.")
-    dag = Dag(collections)
-
     session_class = get_session_class(database_dsn)
     with session_class() as session:
-        latest_success_components_version_log = (
-            get_latest_success_component_version_log(session)
-        )
-        cluster_variables = ClusterVariables.get_cluster_variables(
-            collections, vars, validate=validate
-        )
-        check_services_cleanliness(cluster_variables)
-
         try:
             click.echo(f"Creating a deployment plan to reconfigure services.")
-            deployment_log = DeploymentLog.from_reconfigure(
-                dag, cluster_variables, latest_success_components_version_log
+            stale_components = get_stale_components(session)
+            deployment_log = DeploymentLog.from_stale_components(
+                collections, stale_components
             )
         except Exception as e:
-            raise click.ClickException(f"Failed to create deployment plan: {e}") from e
+            raise click.ClickException(str(e)) from e
         planned_deployment_log = get_planned_deployment_log(session)
         if planned_deployment_log:
             deployment_log.id = planned_deployment_log.id

--- a/tdp/cli/commands/plan/test_reconfigure.py
+++ b/tdp/cli/commands/plan/test_reconfigure.py
@@ -8,16 +8,18 @@ from .reconfigure import reconfigure
 
 
 def test_tdp_plan_reconfigure(collection_path, database_dsn_path, vars):
-    args = [
+    base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
         database_dsn_path,
+    ]
+    init_args = base_args + [
         "--vars",
         vars,
     ]
     runner = CliRunner()
-    result = runner.invoke(init, args)
+    result = runner.invoke(init, init_args)
     assert result.exit_code == 0
-    result = runner.invoke(reconfigure, args)
-    assert result.exit_code == 1  # Nothing to reconfigure
+    result = runner.invoke(reconfigure, base_args)
+    assert result.exit_code == 1  # No stale components, hence nothing to reconfigure.

--- a/tdp/cli/commands/stale/__init__.py
+++ b/tdp/cli/commands/stale/__init__.py
@@ -1,7 +1,6 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import defaultdict
 import click
 from typing import List
 from tabulate import tabulate
@@ -42,54 +41,9 @@ def stale(database_dsn: str, generate: bool, vars, collections):
             deployed_component_version_logs = get_latest_success_component_version_log(
                 session
             )
-            modified_services_or_components_names = (
-                cluster_variables.get_modified_components_names(
-                    services_components_versions=deployed_component_version_logs
-                )
+            stale_components_dict = StaleComponent.generate(
+                dag, cluster_variables, deployed_component_version_logs
             )
-            modified_components_names = set()
-            for modified_component_name in modified_services_or_components_names:
-                click.echo(f"{modified_component_name.full_name} has been modified.")
-                if modified_component_name.is_service:
-                    config_operations_of_the_service = filter(
-                        lambda operation: operation.action_name == "config"
-                        and not operation.is_service_operation(),
-                        dag.services_operations[modified_component_name.service_name],
-                    )
-                    modified_components_names.update(
-                        [
-                            operation.name
-                            for operation in config_operations_of_the_service
-                        ]
-                    )
-                else:
-                    modified_components_names.add(
-                        f"{modified_component_name.full_name}_config"
-                    )
-            operations = dag.get_operations(
-                sources=list(modified_components_names), restart=True
-            )
-            config_and_restart_operations = dag.filter_operations_regex(
-                operations, r".+_(config|(re|)start)"
-            )
-            stale_components_dict = {}
-            for operation in config_and_restart_operations:
-                if operation.is_service_operation():
-                    continue
-                key = (operation.service_name, operation.component_name)
-                stale_component = stale_components_dict.setdefault(
-                    key,
-                    StaleComponent(
-                        service_name=operation.service_name,
-                        component_name=operation.component_name,
-                        to_reconfigure=False,
-                        to_restart=False,
-                    ),
-                )
-                if operation.action_name == "config":
-                    stale_component.to_reconfigure = True
-                if operation.action_name == "restart":
-                    stale_component.to_restart = True
             session.query(StaleComponent).delete()
             session.add_all(list(stale_components_dict.values()))
             session.commit()

--- a/tdp/cli/commands/stale/__init__.py
+++ b/tdp/cli/commands/stale/__init__.py
@@ -6,7 +6,7 @@ from typing import List
 import click
 from tabulate import tabulate
 
-from tdp.cli.queries import get_latest_success_component_version_log
+from tdp.cli.queries import get_latest_success_component_version_log, get_stale_components
 from tdp.cli.session import get_session_class
 from tdp.cli.utils import (
     check_services_cleanliness,
@@ -49,7 +49,7 @@ def stale(database_dsn: str, generate: bool, vars, collections):
             session.add_all(stale_components)
             session.commit()
         # Print stale components
-        stale_components = session.query(StaleComponent).all()
+        stale_components = get_stale_components(session)
         _print_stale_components(stale_components)
 
 

--- a/tdp/cli/commands/stale/__init__.py
+++ b/tdp/cli/commands/stale/__init__.py
@@ -6,7 +6,10 @@ from typing import List
 import click
 from tabulate import tabulate
 
-from tdp.cli.queries import get_latest_success_component_version_log, get_stale_components
+from tdp.cli.queries import (
+    get_latest_success_component_version_log,
+    get_stale_components,
+)
 from tdp.cli.session import get_session_class
 from tdp.cli.utils import (
     check_services_cleanliness,

--- a/tdp/cli/commands/stale/__init__.py
+++ b/tdp/cli/commands/stale/__init__.py
@@ -1,14 +1,13 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-import click
 from typing import List
+
+import click
 from tabulate import tabulate
 
 from tdp.cli.queries import get_latest_success_component_version_log
-from tdp.core.variables import ClusterVariables
 from tdp.cli.session import get_session_class
-from tdp.core.dag import Dag
 from tdp.cli.utils import (
     check_services_cleanliness,
     collections,
@@ -16,7 +15,9 @@ from tdp.cli.utils import (
     validate,
     vars,
 )
+from tdp.core.dag import Dag
 from tdp.core.models import StaleComponent
+from tdp.core.variables import ClusterVariables
 
 
 @click.command(short_help="List stale components.")
@@ -41,11 +42,11 @@ def stale(database_dsn: str, generate: bool, vars, collections):
             deployed_component_version_logs = get_latest_success_component_version_log(
                 session
             )
-            stale_components_dict = StaleComponent.generate(
+            stale_components = StaleComponent.generate(
                 dag, cluster_variables, deployed_component_version_logs
             )
             session.query(StaleComponent).delete()
-            session.add_all(list(stale_components_dict.values()))
+            session.add_all(stale_components)
             session.commit()
         # Print stale components
         stale_components = session.query(StaleComponent).all()

--- a/tdp/cli/commands/stale/__init__.py
+++ b/tdp/cli/commands/stale/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List
+from pathlib import Path
 
 import click
 from tabulate import tabulate
@@ -18,17 +19,21 @@ from tdp.cli.utils import (
     validate,
     vars,
 )
+from tdp.core.collections import Collections
 from tdp.core.dag import Dag
 from tdp.core.models import StaleComponent
 from tdp.core.variables import ClusterVariables
 
 
 @click.command(short_help="List stale components.")
-@database_dsn
-@vars
 @collections
+@database_dsn
 @click.option("--generate", is_flag=True, help="Generate the list of stale components.")
-def stale(database_dsn: str, generate: bool, vars, collections):
+@validate
+@vars
+def stale(
+    collections: Collections, database_dsn: str, generate: bool, validate, vars: Path
+):
     if not vars.exists():
         raise click.BadParameter(f"{vars} does not exist.")
     dag = Dag(collections)

--- a/tdp/cli/queries.py
+++ b/tdp/cli/queries.py
@@ -8,7 +8,24 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session
 
-from tdp.core.models import ComponentVersionLog, DeploymentLog, OperationLog
+from tdp.core.models import (
+    ComponentVersionLog,
+    DeploymentLog,
+    OperationLog,
+    StaleComponent,
+)
+
+
+def get_stale_components(session: Session) -> List[StaleComponent]:
+    """Get stale components.
+
+    Args:
+        session: The database session.
+
+    Returns:
+        The stale components.
+    """
+    return session.query(StaleComponent).all()
 
 
 def get_latest_success_component_version_log(

--- a/tdp/core/deployment/deployment_iterator.py
+++ b/tdp/core/deployment/deployment_iterator.py
@@ -78,8 +78,14 @@ class DeploymentIterator(
                     return operation_log, None, None
 
                 operation = self._collections.get_operation(operation_log.operation)
+                # TODO: operation component_name should be an empty string instead of None when service operation
                 stale_component = self._stale_components.get(
-                    (operation.service_name, operation.component_name)
+                    (
+                        operation.service_name,
+                        operation.component_name
+                        if not operation.is_service_operation()
+                        else "",
+                    )
                 )
                 if operation.action_name == "config":
                     if stale_component:

--- a/tdp/core/deployment/deployment_runner.py
+++ b/tdp/core/deployment/deployment_runner.py
@@ -11,8 +11,8 @@ from tdp.core.models import (
     DeploymentStateEnum,
     OperationLog,
     OperationStateEnum,
+    StaleComponent,
 )
-from tdp.core.operation import Operation
 from tdp.core.variables import ClusterVariables
 
 from .deployment_iterator import DeploymentIterator
@@ -28,6 +28,7 @@ class DeploymentRunner:
         collections: Collections,
         executor: Executor,
         cluster_variables: ClusterVariables,
+        stale_components: list[StaleComponent],
     ):
         """Deployment runner.
 
@@ -35,10 +36,12 @@ class DeploymentRunner:
             collections: Collections object.
             executor: Executor object.
             cluster_variables: ClusterVariables object.
+            stale_components: List of stale components to actualize.
         """
         self._collections = collections
         self._executor = executor
         self._cluster_variables = cluster_variables
+        self._stale_components = stale_components
 
     def _run_operation(self, operation_log: OperationLog):
         """Run operation.
@@ -88,4 +91,5 @@ class DeploymentRunner:
             collections=self._collections,
             run_method=self._run_operation,
             cluster_variables=self._cluster_variables,
+            stale_components=self._stale_components,
         )

--- a/tdp/core/deployment/test_deployment_runner.py
+++ b/tdp/core/deployment/test_deployment_runner.py
@@ -34,12 +34,16 @@ class FailingExecutor(MockExecutor):
 
 @pytest.fixture
 def deployment_runner(minimal_collections, cluster_variables):
-    return DeploymentRunner(minimal_collections, MockExecutor(), cluster_variables)
+    return DeploymentRunner(
+        minimal_collections, MockExecutor(), cluster_variables, stale_components=[]
+    )
 
 
 @pytest.fixture
 def failing_deployment_runner(minimal_collections, cluster_variables):
-    return DeploymentRunner(minimal_collections, FailingExecutor(), cluster_variables)
+    return DeploymentRunner(
+        minimal_collections, FailingExecutor(), cluster_variables, stale_components=[]
+    )
 
 
 def test_deployment_plan_is_success(dag: Dag, deployment_runner: DeploymentRunner):
@@ -47,7 +51,7 @@ def test_deployment_plan_is_success(dag: Dag, deployment_runner: DeploymentRunne
     deployment_log = DeploymentLog.from_dag(dag)
     deployment_iterator = deployment_runner.run(deployment_log)
 
-    for operation, _ in deployment_iterator:
+    for operation, _, _ in deployment_iterator:
         if operation is not None:
             assert operation.state == OperationStateEnum.SUCCESS
 
@@ -65,7 +69,7 @@ def test_deployment_plan_with_filter_is_success(
     )
     deployment_iterator = deployment_runner.run(deployment_log)
 
-    for operation_log, _ in deployment_iterator:
+    for operation_log, _, _ in deployment_iterator:
         if operation_log is not None:
             assert operation_log.state == OperationStateEnum.SUCCESS
 
@@ -78,7 +82,7 @@ def test_noop_deployment_plan_is_success(minimal_collections, deployment_runner)
     deployment_log = DeploymentLog.from_operations(minimal_collections, ["mock_init"])
     deployment_iterator = deployment_runner.run(deployment_log)
 
-    for operation, _ in deployment_iterator:
+    for operation, _, _ in deployment_iterator:
         if operation is not None:
             assert operation.state == OperationStateEnum.SUCCESS
 

--- a/tdp/core/deployment/test_deployment_runner.py
+++ b/tdp/core/deployment/test_deployment_runner.py
@@ -232,26 +232,7 @@ def test_deployment_dag_is_resumed(
     )
 
 
-def test_deployment_is_reconfigured(
-    dag, reconfigurable_cluster_variables, deployment_runner
-):
-    (
-        cluster_variables,
-        component_version_deployed,
-    ) = reconfigurable_cluster_variables
-    deployment_log = DeploymentLog.from_reconfigure(
-        dag, cluster_variables, component_version_deployed
-    )
-    deployment_iterator = deployment_runner.run(deployment_log)
-    for _ in deployment_iterator:
-        pass
-    assert (
-        deployment_iterator.deployment_log.deployment_type
-        == DeploymentTypeEnum.RECONFIGURE
-    )
-    assert len(deployment_iterator.deployment_log.operations) == 4
-
-
+@pytest.mark.skip(reason="from_reconfigure have been removed, to be reworked")
 def test_deployment_reconfigure_is_resumed(
     dag,
     reconfigurable_cluster_variables,

--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -12,10 +12,8 @@ from tabulate import tabulate
 from tdp.core.collections import Collections
 from tdp.core.dag import Dag
 from tdp.core.operation import OPERATION_NAME_MAX_LENGTH
-from tdp.core.variables import ClusterVariables
 
 from .base import Base
-from .component_version_log import ComponentVersionLog
 from .operation_log import OperationLog
 from .stale_component import StaleComponent
 from .state_enum import DeploymentStateEnum, OperationStateEnum
@@ -231,7 +229,7 @@ class DeploymentLog(Base):
 
     @staticmethod
     def from_stale_components(
-        collections: Collections, stale_components: List[StaleComponent]
+        collections: Collections, stale_components: Iterable[Optional[StaleComponent]]
     ) -> "DeploymentLog":
         """Generate a deployment plan from a list of stale components.
 
@@ -255,7 +253,7 @@ class DeploymentLog(Base):
             if stale_component.to_reconfigure:
                 operations_names.add("_".join([base_operation_name, "config"]))
         if len(operations_names) == 0:
-            raise NothingToReconfigureError()
+            raise NothingToReconfigureError(f"No component needs to be reconfigured.")
         dag = Dag(collections)
         operations = dag.topological_sort(nodes=operations_names, restart=True)
         deployment_log = DeploymentLog(

--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -229,7 +229,7 @@ class DeploymentLog(Base):
 
     @staticmethod
     def from_stale_components(
-        collections: Collections, stale_components: Iterable[Optional[StaleComponent]]
+        collections: Collections, stale_components: list[StaleComponent]
     ) -> "DeploymentLog":
         """Generate a deployment plan from a list of stale components.
 

--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -245,15 +245,18 @@ class DeploymentLog(Base):
             # should not append as those components should have been filtered out
             if not stale_component.to_reconfigure and not stale_component.to_restart:
                 continue
-            base_operation_name = "_".join(
-                [stale_component.service_name, stale_component.component_name]
-            )
+            if stale_component.component_name:
+                base_operation_name = "_".join(
+                    [stale_component.service_name, stale_component.component_name]
+                )
+            else:
+                base_operation_name = stale_component.service_name
             if stale_component.to_restart:
                 operations_names.add("_".join([base_operation_name, "start"]))
             if stale_component.to_reconfigure:
                 operations_names.add("_".join([base_operation_name, "config"]))
         if len(operations_names) == 0:
-            raise NothingToReconfigureError(f"No component needs to be reconfigured.")
+            raise NothingToReconfigureError("No component needs to be reconfigured.")
         dag = Dag(collections)
         operations = dag.topological_sort(nodes=operations_names, restart=True)
         deployment_log = DeploymentLog(

--- a/tdp/core/models/stale_component.py
+++ b/tdp/core/models/stale_component.py
@@ -13,8 +13,6 @@ from tdp.core.models.component_version_log import ComponentVersionLog
 from tdp.core.operation import COMPONENT_NAME_MAX_LENGTH, SERVICE_NAME_MAX_LENGTH
 from tdp.core.variables import ClusterVariables
 
-logger = logging.getLogger("tdp").getChild("stale_component")
-
 
 class StaleComponent(Base):
     """Hold what components are staled.
@@ -28,12 +26,8 @@ class StaleComponent(Base):
 
     __tablename__ = "stale_component"
 
-    service_name = Column(
-        String(length=SERVICE_NAME_MAX_LENGTH), primary_key=True, nullable=False
-    )
-    component_name = Column(
-        String(length=COMPONENT_NAME_MAX_LENGTH), primary_key=True, nullable=True
-    )
+    service_name = Column(String(length=SERVICE_NAME_MAX_LENGTH), primary_key=True)
+    component_name = Column(String(length=COMPONENT_NAME_MAX_LENGTH), primary_key=True)
     to_reconfigure = Column(Boolean, default=False)
     to_restart = Column(Boolean, default=False)
 
@@ -43,45 +37,26 @@ class StaleComponent(Base):
         cluster_variables: ClusterVariables,
         deployed_component_version_logs: ComponentVersionLog,
     ) -> list[StaleComponent]:
-        modified_services_or_components_names = (
-            cluster_variables.get_modified_components_names(
+        sources_config_operations = [
+            service_component_name.full_name + "_config"
+            for service_component_name in cluster_variables.get_modified_services_components_names(
                 services_components_versions=deployed_component_version_logs
             )
-        )
-        modified_components_names = set()
-        for modified_component_name in modified_services_or_components_names:
-            logger.debug(f"{modified_component_name.full_name} has been modified.")
-            if modified_component_name.is_service:
-                config_operations_of_the_service = filter(
-                    lambda operation: operation.action_name == "config"
-                    and not operation.is_service_operation(),
-                    dag.services_operations[modified_component_name.service_name],
-                )
-                modified_components_names.update(
-                    [operation.name for operation in config_operations_of_the_service]
-                )
-            else:
-                modified_components_names.add(
-                    f"{modified_component_name.full_name}_config"
-                )
-        if not modified_components_names:
-            return []
-        operations = dag.get_operations(
-            sources=list(modified_components_names), restart=True
-        )
+        ]
+        operations = dag.get_operations(sources=sources_config_operations, restart=True)
         config_and_restart_operations = dag.filter_operations_regex(
-            operations, r".+_(config|(re|)start)"
+            operations, r".+_(config|restart)"
         )
         stale_components_dict = {}
         for operation in config_and_restart_operations:
-            if operation.is_service_operation():
-                continue
             key = (operation.service_name, operation.component_name)
             stale_component = stale_components_dict.setdefault(
                 key,
                 StaleComponent(
                     service_name=operation.service_name,
-                    component_name=operation.component_name,
+                    component_name=operation.component_name
+                    if not operation.is_service_operation()
+                    else "",
                     to_reconfigure=False,
                     to_restart=False,
                 ),

--- a/tdp/core/models/stale_component.py
+++ b/tdp/core/models/stale_component.py
@@ -52,6 +52,18 @@ class StaleComponent(Base):
             service_component_name.full_name + "_config"
             for service_component_name in modified_services_components_names
         ]
+        #  When a service is modified, extend operation list with its components
+        for modified_service_component_name in modified_services_components_names:
+            if modified_service_component_name.is_service:
+                service_operations = filter(
+                    lambda operation: operation.action_name == "config",
+                    dag.services_operations[
+                        modified_service_component_name.service_name
+                    ],
+                )
+                sources_config_operations.extend(
+                    [service_operation.name for service_operation in service_operations]
+                )
         operations = dag.get_operations(sources=sources_config_operations, restart=True)
         config_and_restart_operations = dag.filter_operations_regex(
             operations, r".+_(config|restart)"

--- a/tdp/core/models/stale_component.py
+++ b/tdp/core/models/stale_component.py
@@ -35,8 +35,11 @@ class StaleComponent(Base):
     def generate(
         dag: Dag,
         cluster_variables: ClusterVariables,
-        deployed_component_version_logs: ComponentVersionLog,
+        deployed_component_version_logs: list[ComponentVersionLog],
     ) -> list[StaleComponent]:
+        # Nothing is deployed (empty cluster)
+        if len(deployed_component_version_logs) == 0:
+            return []
         sources_config_operations = [
             service_component_name.full_name + "_config"
             for service_component_name in cluster_variables.get_modified_services_components_names(

--- a/tdp/core/models/stale_component.py
+++ b/tdp/core/models/stale_component.py
@@ -64,6 +64,8 @@ class StaleComponent(Base):
                 modified_components_names.add(
                     f"{modified_component_name.full_name}_config"
                 )
+        if not modified_components_names:
+            return []
         operations = dag.get_operations(
             sources=list(modified_components_names), restart=True
         )

--- a/tdp/core/models/stale_component.py
+++ b/tdp/core/models/stale_component.py
@@ -40,11 +40,17 @@ class StaleComponent(Base):
         # Nothing is deployed (empty cluster)
         if len(deployed_component_version_logs) == 0:
             return []
+        modified_services_components_names = (
+            cluster_variables.get_modified_services_components_names(
+                deployed_component_version_logs
+            )
+        )
+        # No configuration have been modified (clean cluster)
+        if len(modified_services_components_names) == 0:
+            return []
         sources_config_operations = [
             service_component_name.full_name + "_config"
-            for service_component_name in cluster_variables.get_modified_services_components_names(
-                services_components_versions=deployed_component_version_logs
-            )
+            for service_component_name in modified_services_components_names
         ]
         operations = dag.get_operations(sources=sources_config_operations, restart=True)
         config_and_restart_operations = dag.filter_operations_regex(

--- a/tdp/core/models/test_stale_component.py
+++ b/tdp/core/models/test_stale_component.py
@@ -1,3 +1,7 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+
 from .stale_component import StaleComponent
 
 

--- a/tdp/core/models/test_stale_component.py
+++ b/tdp/core/models/test_stale_component.py
@@ -1,0 +1,68 @@
+from .stale_component import StaleComponent
+
+
+def test_stale_components_to_dict():
+    stale_component1 = StaleComponent(
+        service_name="service",
+        component_name="component1",
+        to_reconfigure=True,
+        to_restart=True,
+    )
+    stale_component2 = StaleComponent(
+        service_name="service",
+        component_name="component2",
+        to_reconfigure=False,
+        to_restart=True,
+    )
+    stale_components_dict = StaleComponent.to_dict([stale_component1, stale_component2])
+
+    assert stale_components_dict == {
+        ("service", "component1"): stale_component1,
+        ("service", "component2"): stale_component2,
+    }
+
+
+def test_stale_components_to_dict_empty():
+    stale_components_dict = StaleComponent.to_dict([])
+    assert stale_components_dict == {}
+
+
+def test_stale_components_to_dict_duplicate():
+    stale_component1 = StaleComponent(
+        service_name="service",
+        component_name="component",
+        to_reconfigure=True,
+        to_restart=True,
+    )
+    stale_component2 = StaleComponent(
+        service_name="service",
+        component_name="component",
+        to_reconfigure=False,
+        to_restart=True,
+    )
+    stale_components_dict = StaleComponent.to_dict([stale_component1, stale_component2])
+
+    assert stale_components_dict == {
+        ("service", "component"): stale_component2,
+    }
+
+
+def test_stale_components_to_dict_empty_component():
+    stale_component1 = StaleComponent(
+        service_name="service",
+        component_name="",
+        to_reconfigure=True,
+        to_restart=True,
+    )
+    stale_component2 = StaleComponent(
+        service_name="service",
+        component_name="component",
+        to_reconfigure=False,
+        to_restart=True,
+    )
+    stale_components_dict = StaleComponent.to_dict([stale_component1, stale_component2])
+
+    assert stale_components_dict == {
+        ("service", ""): stale_component1,
+        ("service", "component"): stale_component2,
+    }

--- a/tdp/core/variables/cluster_variables.py
+++ b/tdp/core/variables/cluster_variables.py
@@ -168,7 +168,7 @@ class ClusterVariables(MappingType[str, ServiceVariables]):
         for service in self.values():
             service.validate()
 
-    def get_modified_components_names(
+    def get_modified_services_components_names(
         self,
         services_components_versions: Iterable[ComponentVersionLog],
     ) -> Set[ServiceComponentName]:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Part of #378 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

- Reconfigure now uses stale component.
- Each deployment updates the stale table.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
