### PR TITLE
fix: remove sqlalchemy warning

### DIFF
--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -103,8 +103,9 @@ class DeploymentLog(Base):
         order_by="OperationLog.operation_order",
         cascade="all, delete-orphan",
     )
-    component_version = relationship("ComponentVersionLog", back_populates="deployment")
-
+    component_version = relationship(
+        "ComponentVersionLog", back_populates="deployment", cascade_backrefs=False
+    )
 
     def __str__(self):
         return tabulate(


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Remove the following error.

> /tdp/core/deployment/deployment_iterator.py:92: RemovedIn20Warning: "ComponentVersionLog" object is being merged into a Session along the backref cascade path for relationship "DeploymentLog.component_version"; in SQLAlchemy 2.0, this reverse cascade will not take place.  Set cascade_backrefs to False in either the relationship() or backref() function for the 2.0 behavior; or to set globally for the whole Session, set the future=True flag (Background on this error at: https://sqlalche.me/e/14/s9r1) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    component_version_log.deployment = self.deployment_log

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
