### PR TITLE
fix: iterator dissociate hosts for component version logs

### DIFF
--- a/tdp/core/deployment/deployment_iterator.py
+++ b/tdp/core/deployment/deployment_iterator.py
@@ -128,7 +128,11 @@ class DeploymentIterator(
                 # For now, it is still needed for the first deployment (no stale component)
                 component_version_logs: list[ComponentVersionLog] = []
                 component_state = self._component_states[
-                    (operation.service_name, operation.component_name)
+                    (
+                        operation.service_name,
+                        operation.component_name,
+                        operation_log.host,
+                    )
                 ]
                 if operation.action_name == "config":
                     component_state.is_configured = True


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Fix iterator so that it can create version log for component **on each host**.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
