### PR TITLE
fix: use ansible utils for parsing yaml

### DIFF
--- a/tdp/core/variables/variables.py
+++ b/tdp/core/variables/variables.py
@@ -9,12 +9,12 @@ from weakref import proxy
 
 import yaml
 from ansible.utils.vars import merge_hash as _merge_hash
+from ansible.parsing.utils.yaml import from_yaml
 
 try:
     from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
 except ImportError:
-    from yaml import Dumper, Loader
+    from yaml import Dumper
 
 
 # https://stackoverflow.com/a/33300001
@@ -151,7 +151,7 @@ class _VariablesIOWrapper(VariablesDict):
         """
         self._file_path = path
         self._file_descriptor = open(self._file_path, mode or "r+")
-        self._content = yaml.load(self._file_descriptor, Loader=Loader) or {}
+        self._content = from_yaml(self._file_descriptor) or {}
         self._name = path.name
 
     def __enter__(self):


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #399

#### Additional comments

I found similar issue and fix here https://stackoverflow.com/questions/69817464/pyyaml-error-could-not-determine-a-constructor-for-the-tag-vault

Basically I used the ansible utils yaml parser instead of the default pyyaml parser. It seems like an OK fix to me but I might forget something.

I did test using a debug msg in a collection and the var is correctly decrypted.

The PR is provided as a suggestion, I'm not familiar enough with the lib anyway

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
