### PR TITLE
refactor: replace OrderedDict with dict

### DIFF
--- a/tdp/core/variables/service_variables.py
+++ b/tdp/core/variables/service_variables.py
@@ -7,7 +7,7 @@ import os
 from collections import OrderedDict
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, Union
+from typing import TYPE_CHECKING, Generator, Union
 
 import jsonschema
 from jsonschema import exceptions
@@ -180,7 +180,7 @@ class ServiceVariables:
     @contextmanager
     def open_var_files(
         self, message: str, paths: list[str], fail_if_does_not_exist: bool = False
-    ) -> Iterator[OrderedDict[str, Variables]]:
+    ) -> Generator[OrderedDict[str, Variables], None, None]:
         """Open variables files.
 
         Adds the underlying files for validation.

--- a/tdp/core/variables/service_variables.py
+++ b/tdp/core/variables/service_variables.py
@@ -180,9 +180,7 @@ class ServiceVariables:
     @contextmanager
     def open_var_files(
         self, message: str, paths: list[str], fail_if_does_not_exist: bool = False
-    ) -> Iterator[
-        dict[str, Variables]
-    ]:  # TODO: Transform Dict to OrderedDict with python>3.6
+    ) -> Iterator[OrderedDict[str, Variables]]:
         """Open variables files.
 
         Adds the underlying files for validation.


### PR DESCRIPTION
#### Which issue(s) this PR fixes

Part of #369

#### Additional comments

This seams to be already fixed:

> - Explicit the correct types for classes that inherit from the `Mapping` abc (as `Collections`)
> - Use `list` instead of `List`

I am not sure if there is smth else to refactor. Checked with [whats new in python 3.9](https://docs.python.org/3/whatsnew/3.9.html).

#### Agreements


- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
