### PR TITLE
feat: improve browse message

### DIFF
--- a/tdp/cli/commands/browse.py
+++ b/tdp/cli/commands/browse.py
@@ -83,16 +83,19 @@ def _print_formatted_deployments(deployments: list[DeploymentLog]) -> None:
     headers = DeploymentLog.__table__.columns.keys() + [
         str(DeploymentLog.component_version).split(".")[1]
     ]
-    click.echo(
-        "Deployments:\n"
-        + tabulate(
-            [
-                _format_deployment_log(deployment_log, headers)
-                for deployment_log in deployments
-            ],
-            headers="keys",
+    if deployments:
+        click.echo(
+            "Deployments:\n"
+            + tabulate(
+                [
+                    _format_deployment_log(deployment_log, headers)
+                    for deployment_log in deployments
+                ],
+                headers="keys",
+            )
         )
-    )
+    else:
+        click.echo("No deployments found, create a deployment plan with `tdp plan`.")
 
 
 def _print_formatted_deployment(deployment_log: DeploymentLog) -> None:


### PR DESCRIPTION

#### Which issue(s) this PR fixes

Fixes #421

#### Additional comments

Example message:
```
➜ tdp browse  
2023-09-01 12:02:49,805 - DEBUG - tdp.<module> - Logger initialized
No deployments found, create a deployment plan with `tdp plan`.
```

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
