### PR TITLE
423 `tdp` command with no arguments should print the usage help

### DIFF
--- a/tdp/cli/__main__.py
+++ b/tdp/cli/__main__.py
@@ -21,7 +21,7 @@ from tdp.cli.commands.validate import validate
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
-@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
+@click.group(context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--env",
     default=".env",


### PR DESCRIPTION
#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #423

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

This fixes the issue by using the default click behaviour being 

> By default, a group or multi command is not invoked unless a subcommand is passed. In fact, not providing a command automatically passes --help by default

If we do not want such behaviour, we should implement a context such as this:

```
@click.pass_context
def cli(ctx):
    if ctx.invoked_subcommand is None:
        click.echo('I was invoked without subcommand')
    else:
        click.echo('I am about to invoke %s' % ctx.invoked_subcommand)
```

It is a quick fix for a very minor behaviour. I haven't seen in the history why this behaviour was added (in PR #287)

Link: https://click.palletsprojects.com/en/7.x/commands/

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions. 
