### PR TITLE
refactor: add to_dict method to models

### DIFF
--- a/tdp/core/models/base.py
+++ b/tdp/core/models/base.py
@@ -1,32 +1,23 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Tuple
+from typing import Any
 
 from sqlalchemy.orm import DeclarativeBase
-
-
-def keyvalgen(obj: object) -> Tuple[str, Any]:
-    # From: https://stackoverflow.com/a/54034230
-    """Generate key-value pairs from an object.
-
-    Exclude keys starting with an underscore and keys that are SQLAlchemy.
-
-    Args:
-        obj: Object to generate key-value pairs from.
-
-    Yields:
-        tuple of key-value pair.
-    """
-    excl = ("_sa_adapter", "_sa_instance_state")
-    for k, v in vars(obj).items():
-        if not k.startswith("_") and not any(hasattr(v, a) for a in excl):
-            yield k, v
 
 
 class Base(DeclarativeBase):
     """Custom base class for SQLAlchemy models."""
 
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the model to a dictionary.
+
+        Returns:
+            Dictionary representation of the model.
+        """
+        return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+
     def __repr__(self):
-        params = ", ".join(f"{k}={v}" for k, v in keyvalgen(self))
-        return f"{self.__class__.__name__}({params})"
+        """Return a string representation of the model."""
+        values = ", ".join(f"{key}={value}" for key, value in self.to_dict().items())
+        return f"{self.__class__.__name__}({values})"

--- a/tdp/core/models/test_base.py
+++ b/tdp/core/models/test_base.py
@@ -4,7 +4,7 @@
 import pytest
 from sqlalchemy import Column, Integer, String
 
-from tdp.core.models.base import Base, keyvalgen
+from tdp.core.models.base import Base
 
 
 class ExampleClass(Base):
@@ -20,10 +20,9 @@ def test_instance() -> ExampleClass:
     return instance
 
 
-def test_keyvalgen(test_instance: ExampleClass):
-    gen = keyvalgen(test_instance)
-    attrs = dict(gen)
-    assert attrs == {"id": 1, "name": "TestName"}
+def test_custom_base_to_dict(test_instance: ExampleClass):
+    dict_repr = test_instance.to_dict()
+    assert dict_repr == {"id": 1, "name": "TestName"}
 
 
 def test_custom_base_repr(test_instance: ExampleClass):


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Create a to_dict method to get sqlalchemy model as dict. It is now used by str and will later be used in the browse method. I'll wait for this PR to be merged before implementing it.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
