### PR TITLE
Remove `None` values from `tdp browse` command output

### DIFF
--- a/tdp/core/models/base.py
+++ b/tdp/core/models/base.py
@@ -61,4 +61,6 @@ class Base(DeclarativeBase):
                 .astimezone(LOCAL_TIMEZONE)
                 .strftime("%Y-%m-%d %H:%M:%S")
             )
+        elif value is None:
+            return ""
         return str(value)


### PR DESCRIPTION
Having None values in the hosts column was confusing.

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Replace `None` values by empty strings from the table of the `tdp browse` command. It was confusing to have `None` displayed in the "host" column.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
