### PR TITLE
refactor: rename tdp plan run to tdp plan ops

### DIFF
--- a/tdp/cli/commands/plan/__init__.py
+++ b/tdp/cli/commands/plan/__init__.py
@@ -4,9 +4,9 @@
 import click
 
 from tdp.cli.commands.plan.dag import dag
+from tdp.cli.commands.plan.ops import ops
 from tdp.cli.commands.plan.reconfigure import reconfigure
 from tdp.cli.commands.plan.resume import resume
-from tdp.cli.commands.plan.run import run
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -20,7 +20,7 @@ def plan():
     pass
 
 
-plan.add_command(run)
-plan.add_command(resume)
-plan.add_command(reconfigure)
 plan.add_command(dag)
+plan.add_command(ops)
+plan.add_command(reconfigure)
+plan.add_command(resume)

--- a/tdp/cli/commands/plan/ops.py
+++ b/tdp/cli/commands/plan/ops.py
@@ -36,7 +36,7 @@ from tdp.core.models import DeploymentLog
 @database_dsn
 @preview
 @rolling_interval
-def run(
+def ops(
     operation_names,
     host,
     extra_vars,

--- a/tdp/cli/commands/plan/test_ops.py
+++ b/tdp/cli/commands/plan/test_ops.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from tdp.cli.commands.init import init
-from tdp.cli.commands.plan.run import run
+from tdp.cli.commands.plan.ops import ops
 
 
 def test_tdp_plan_run(collection_path: Path, database_dsn_path: str, vars: Path):
@@ -19,5 +19,5 @@ def test_tdp_plan_run(collection_path: Path, database_dsn_path: str, vars: Path)
     runner = CliRunner()
     result = runner.invoke(init, [*base_args, "--vars", str(vars)])
     assert result.exit_code == 0, result.output
-    result = runner.invoke(run, [*base_args, "service_install"])
+    result = runner.invoke(ops, [*base_args, "service_install"])
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Rename `tdp plan run` to `tdp plan ops` to avoid confusions.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
