### PR TITLE
Rename `timestamp` column to `event_time`

### DIFF
--- a/tdp/cli/queries.py
+++ b/tdp/cli/queries.py
@@ -44,7 +44,7 @@ def get_sch_status(
                 case(
                     (
                         SCHStatusLog.configured_version != None,
-                        SCHStatusLog.timestamp,
+                        SCHStatusLog.event_time,
                     )
                 )
             ).label("latest_configured_version_timestamp"),
@@ -66,7 +66,7 @@ def get_sch_status(
                 case(
                     (
                         SCHStatusLog.running_version != None,
-                        SCHStatusLog.timestamp,
+                        SCHStatusLog.event_time,
                     )
                 )
             ).label("latest_running_version_timestamp"),
@@ -85,7 +85,7 @@ def get_sch_status(
             SCHStatusLog.component,
             SCHStatusLog.host,
             func.max(
-                case((SCHStatusLog.to_config != None, SCHStatusLog.timestamp))
+                case((SCHStatusLog.to_config != None, SCHStatusLog.event_time))
             ).label("latest_to_config_timestamp"),
         )
         .group_by(
@@ -102,7 +102,7 @@ def get_sch_status(
             SCHStatusLog.component,
             SCHStatusLog.host,
             func.max(
-                case((SCHStatusLog.to_restart != None, SCHStatusLog.timestamp))
+                case((SCHStatusLog.to_restart != None, SCHStatusLog.event_time))
             ).label("latest_to_restart_timestamp"),
         )
         .group_by(
@@ -120,7 +120,7 @@ def get_sch_status(
             SCHStatusLog.component,
             SCHStatusLog.host,
             SCHStatusLog.configured_version,
-            SCHStatusLog.timestamp,
+            SCHStatusLog.event_time,
         )
         .join(
             latest_configured_version_timestamp_subquery,
@@ -140,7 +140,7 @@ def get_sch_status(
                     == latest_configured_version_timestamp_subquery.c.host,
                 ),
                 # Join based on matching timestamps for all the columns in the subquery.
-                SCHStatusLog.timestamp
+                SCHStatusLog.event_time
                 == latest_configured_version_timestamp_subquery.c.latest_configured_version_timestamp,
             ),
         )
@@ -153,7 +153,7 @@ def get_sch_status(
             SCHStatusLog.component,
             SCHStatusLog.host,
             SCHStatusLog.running_version,
-            SCHStatusLog.timestamp,
+            SCHStatusLog.event_time,
         )
         .join(
             latest_running_version_timestamp_subquery,
@@ -173,7 +173,7 @@ def get_sch_status(
                     == latest_running_version_timestamp_subquery.c.host,
                 ),
                 # Join based on matching timestamps for all the columns in the subquery.
-                SCHStatusLog.timestamp
+                SCHStatusLog.event_time
                 == latest_running_version_timestamp_subquery.c.latest_running_version_timestamp,
             ),
         )
@@ -186,7 +186,7 @@ def get_sch_status(
             SCHStatusLog.component,
             SCHStatusLog.host,
             SCHStatusLog.to_config,
-            SCHStatusLog.timestamp,
+            SCHStatusLog.event_time,
         )
         .join(
             latest_to_config_timestamp_subquery,
@@ -204,7 +204,7 @@ def get_sch_status(
                     SCHStatusLog.host == latest_to_config_timestamp_subquery.c.host,
                 ),
                 # Join based on matching timestamps for all the columns in the subquery.
-                SCHStatusLog.timestamp
+                SCHStatusLog.event_time
                 == latest_to_config_timestamp_subquery.c.latest_to_config_timestamp,
             ),
         )
@@ -217,7 +217,7 @@ def get_sch_status(
             SCHStatusLog.component,
             SCHStatusLog.host,
             SCHStatusLog.to_restart,
-            SCHStatusLog.timestamp,
+            SCHStatusLog.event_time,
         )
         .join(
             latest_to_restart_timestamp_subquery,
@@ -235,7 +235,7 @@ def get_sch_status(
                     SCHStatusLog.host == latest_to_restart_timestamp_subquery.c.host,
                 ),
                 # Join based on matching timestamps for all the columns in the subquery.
-                SCHStatusLog.timestamp
+                SCHStatusLog.event_time
                 == latest_to_restart_timestamp_subquery.c.latest_to_restart_timestamp,
             ),
         )
@@ -267,8 +267,8 @@ def get_sch_status(
                     SCHStatusLog.host == None,
                     SCHStatusLog.host == latest_running_version_value_subquery.c.host,
                 ),
-                SCHStatusLog.timestamp
-                == latest_running_version_value_subquery.c.timestamp,
+                SCHStatusLog.event_time
+                == latest_running_version_value_subquery.c.event_time,
             ),
         )
         .outerjoin(
@@ -288,8 +288,8 @@ def get_sch_status(
                     SCHStatusLog.host
                     == latest_configured_version_value_subquery.c.host,
                 ),
-                SCHStatusLog.timestamp
-                == latest_configured_version_value_subquery.c.timestamp,
+                SCHStatusLog.event_time
+                == latest_configured_version_value_subquery.c.event_time,
             ),
         )
         .outerjoin(
@@ -307,7 +307,7 @@ def get_sch_status(
                     SCHStatusLog.host == None,
                     SCHStatusLog.host == latest_to_config_value_subquery.c.host,
                 ),
-                SCHStatusLog.timestamp == latest_to_config_value_subquery.c.timestamp,
+                SCHStatusLog.event_time == latest_to_config_value_subquery.c.event_time,
             ),
         )
         .outerjoin(
@@ -325,7 +325,8 @@ def get_sch_status(
                     SCHStatusLog.host == None,
                     SCHStatusLog.host == latest_to_restart_value_subquery.c.host,
                 ),
-                SCHStatusLog.timestamp == latest_to_restart_value_subquery.c.timestamp,
+                SCHStatusLog.event_time
+                == latest_to_restart_value_subquery.c.event_time,
             ),
         )
         .group_by(

--- a/tdp/core/models/sch_status_log.py
+++ b/tdp/core/models/sch_status_log.py
@@ -33,7 +33,7 @@ class SCHStatusLog(Base):
     id: Mapped[int] = mapped_column(
         doc="Unique id of the cluster status log.", primary_key=True
     )
-    timestamp: Mapped[datetime] = mapped_column(
+    event_time: Mapped[datetime] = mapped_column(
         default=datetime.utcnow,
         doc="Timestamp of the component version log.",
     )


### PR DESCRIPTION
timestamp is a reserved SQL word.

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Rename the `timestamp` column to `event_time` as `TIMESTAMP` is a reserved SQL keyword.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
