### PR TITLE
476 tdp operations

### DIFF
--- a/tdp/cli/__main__.py
+++ b/tdp/cli/__main__.py
@@ -13,7 +13,7 @@ from tdp.cli.commands.dag import dag
 from tdp.cli.commands.default_diff import default_diff
 from tdp.cli.commands.deploy import deploy
 from tdp.cli.commands.init import init
-from tdp.cli.commands.operations import operations
+from tdp.cli.commands.operations import ops
 from tdp.cli.commands.plan import plan
 from tdp.cli.commands.playbooks import playbooks
 from tdp.cli.commands.status import status
@@ -62,7 +62,7 @@ def main():
     cli.add_command(default_diff)
     cli.add_command(deploy)
     cli.add_command(init)
-    cli.add_command(operations)
+    cli.add_command(ops)
     cli.add_command(plan)
     cli.add_command(playbooks)
     cli.add_command(status)

--- a/tdp/cli/commands/operations.py
+++ b/tdp/cli/commands/operations.py
@@ -54,11 +54,13 @@ def ops(
             sorted_operations = sorted(operations, key=lambda operation: operation.name)
         _print_operations(sorted_operations)
     else:
-        _print_operations(
-            sorted(
-                collections.operations.values(), key=lambda operation: operation.name
-            )
-        )
+        operations = [
+            operation
+            for operation in collections.operations.values()
+            if len(hosts) == 0 or bool(set(operation.host_names) & set(hosts))
+        ]
+        sorted_operations = sorted(operations, key=lambda operation: operation.name)
+        _print_operations(sorted_operations)
 
 
 def _print_operations(operations: Iterable[Operation], /):

--- a/tdp/cli/commands/operations.py
+++ b/tdp/cli/commands/operations.py
@@ -28,7 +28,7 @@ from tdp.core.operation import Operation
     help="Display DAG operations in topological order.",
 )
 @collections
-def operations(
+def ops(
     collections: Collections,
     display_dag_operations: bool,
     hosts: list[str],

--- a/tdp/cli/commands/test_operations.py
+++ b/tdp/cli/commands/test_operations.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.operations import operations
+from tdp.cli.commands.operations import ops
 
 
 def test_tdp_nodes(collection_path: Path):
     args = ["--collection-path", collection_path]
     runner = CliRunner()
-    result = runner.invoke(operations, args)
+    result = runner.invoke(ops, args)
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
#### Which issue(s) this PR fixes

Fixes #476

#### Additional comments

- Changed the name of the command `tdp operation` to `tdp ops`.
- Fixed the issue where the `--host` argument was only working when adding the `--dag` option.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
