### PR TITLE
refactor: rename deployment and operation tables

### DIFF
--- a/tdp/core/models/deployment_log.py
+++ b/tdp/core/models/deployment_log.py
@@ -61,7 +61,7 @@ class DeploymentLog(Base):
     Hold past and current deployment information.
     """
 
-    __tablename__ = "deployment_log"
+    __tablename__ = "deployment"
 
     id: Mapped[int] = mapped_column(primary_key=True, doc="Deployment log id.")
     options: Mapped[Optional[dict]] = mapped_column(

--- a/tdp/core/models/operation_log.py
+++ b/tdp/core/models/operation_log.py
@@ -23,10 +23,10 @@ class OperationLog(Base):
     Hold past and current operation information linked to a deployment.
     """
 
-    __tablename__ = "operation_log"
+    __tablename__ = "operation"
 
     deployment_id: Mapped[int] = mapped_column(
-        ForeignKey("deployment_log.id"), primary_key=True, doc="Deployment log id."
+        ForeignKey("deployment.id"), primary_key=True, doc="Deployment log id."
     )
     operation_order: Mapped[int] = mapped_column(
         primary_key=True, doc="Operation order."

--- a/tdp/core/models/sch_status_log.py
+++ b/tdp/core/models/sch_status_log.py
@@ -64,7 +64,7 @@ class SCHStatusLog(Base):
         doc="Source of the status log.",
     )
     deployment_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("deployment_log.id"),
+        ForeignKey("deployment.id"),
         doc="Related deployment log id (if applicable).",
     )
     message: Mapped[Optional[str]] = mapped_column(


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Remove `_log` suffix from `deployment_log` and `operation_log` table names  as they are not true logs.

I'll do a follow up PR to rename the classes accordingly.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
