### PR TITLE
Prevent display full logs when browsing a deployment

### DIFF
--- a/tdp/cli/commands/browse.py
+++ b/tdp/cli/commands/browse.py
@@ -98,7 +98,7 @@ def _print_deployment(deployment: DeploymentLog) -> None:
         click.echo("Deployment does not exist.")
         return
 
-    print_deployment(deployment)
+    print_deployment(deployment, filter_out=["logs"])
 
 
 def _print_operations(operations: list[OperationLog]) -> None:

--- a/tdp/cli/utils.py
+++ b/tdp/cli/utils.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import click
 from click.decorators import FC
@@ -133,15 +133,17 @@ def preview(func: FC) -> FC:
     )(func)
 
 
-def print_deployment(deployment: DeploymentLog) -> None:
+def print_deployment(
+    deployment: DeploymentLog, /, *, filter_out: Optional[list[str]] = None
+) -> None:
     # Print general deployment infos
     click.secho("Deployment details", bold=True)
-    click.echo(print_object(deployment.to_dict()))
+    click.echo(print_object(deployment.to_dict(filter_out=filter_out)))
 
     # Print deployment operations
     click.secho("\nOperations", bold=True)
     print_table(
-        [o.to_dict() for o in deployment.operations],
+        [o.to_dict(filter_out=filter_out) for o in deployment.operations],
     )
 
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

When browsing through a deployment, it is not useful to display the first few words of each operation logs.

They are still visible when browsing the operation (`tdp browse <id> <operation>`

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
