### PR TITLE
fix: save state in the database after each operation execution

### DIFF
--- a/tdp/cli/commands/deploy.py
+++ b/tdp/cli/commands/deploy.py
@@ -93,11 +93,13 @@ def deploy(
                 pass
             return
 
+        # deployment and operations records are mutated by the iterator so we need to
+        # commit them before iterating and at each iteration
         session.commit()  # Update deployment status to RUNNING
         for cluster_status_logs in deployment_iterator:
             if cluster_status_logs and any(cluster_status_logs):
                 session.add_all(cluster_status_logs)
-                session.commit()
+            session.commit()
 
         if deployment_iterator.deployment.status != DeploymentStateEnum.SUCCESS:
             raise click.ClickException("Deployment failed.")


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Update operation records in the database after each operation execution. This has been broken by the last refactor.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
