### PR TITLE
feat: `--last` option on `tdp browse`

### DIFF
--- a/tdp/cli/commands/browse.py
+++ b/tdp/cli/commands/browse.py
@@ -27,6 +27,12 @@ from tdp.core.models import DeploymentModel, OperationModel
     help="Print the planned deployment, if exist.",
 )
 @click.option(
+    "-l",
+    "--last",
+    is_flag=True,
+    help="Print the last deployment.",
+)
+@click.option(
     "--limit",
     envvar="TDP_LIMIT",
     type=int,
@@ -43,6 +49,7 @@ from tdp.core.models import DeploymentModel, OperationModel
 @database_dsn
 def browse(
     plan: bool,
+    last: bool,
     limit: int,
     offset: int,
     database_dsn: str,
@@ -58,6 +65,14 @@ def browse(
                 _print_deployment(deployment_plan)
             else:
                 click.echo("No planned deployment found")
+                click.echo("Create a deployment plan using the `tdp plan` command")
+            return
+        elif last:
+            deployment = get_deployments(session, limit=1, offset=0)
+            if deployment:
+                _print_deployment(deployment[0])
+            else:
+                click.echo("No deployment found")
                 click.echo("Create a deployment plan using the `tdp plan` command")
             return
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Add an option to print last deployment in browse command as it is the most common usage.

Usage:

```sh
tdp browse --last
```

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
