### PR TITLE
Add color on ansible logs

### DIFF
--- a/tdp/core/deployment/executor.py
+++ b/tdp/core/deployment/executor.py
@@ -3,6 +3,7 @@
 
 import io
 import logging
+import os
 import shutil
 import subprocess
 from collections.abc import Iterable
@@ -46,6 +47,7 @@ class Executor:
                     stderr=subprocess.STDOUT,
                     cwd=self._rundir,
                     universal_newlines=True,
+                    env=os.environ | {"ANSIBLE_FORCE_COLOR": "true"},
                 )
                 if res.stdout is None:
                     raise Exception("Process has not stdout")


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Add `ANSIBLE_FORCE_COLOR` environment variable to the ansible subprocess to enable color on logs.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
