### PR TITLE
Prevent failure when rolling interval on `tdp plan ops`

### DIFF
--- a/tdp/core/models/deployment_model.py
+++ b/tdp/core/models/deployment_model.py
@@ -240,7 +240,7 @@ class DeploymentModel(BaseModel):
                         OperationModel(
                             operation=OPERATION_SLEEP_NAME,
                             operation_order=i,
-                            host=host_name,
+                            host=None,
                             extra_vars=[
                                 f"{OPERATION_SLEEP_VARIABLE}={rolling_interval}"
                             ],


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

The `tdp plan ops` command used with the `--rolling-interval` option caused the deployment to failed because of an host issue. Host should not be specified for the `wait_sleep` playbook.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
