### PR TITLE
Fix `Variables.merge` param type

### DIFF
--- a/tdp/core/variables/variables.py
+++ b/tdp/core/variables/variables.py
@@ -75,7 +75,7 @@ class VariablesDict(MutableMapping):
         """
         return self._content.copy()
 
-    def merge(self, mapping: dict) -> None:
+    def merge(self, mapping: MutableMapping) -> None:
         """Merges the provided mapping into the content.
 
         Args:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

Fix `Variables.merge` param type from `dict` to `MutableMapping` to be coherent with Ansible `merge_hash` method.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
