### PR TITLE
Check if file is writable before flushing

### DIFF
--- a/tdp/core/variables/test_variables.py
+++ b/tdp/core/variables/test_variables.py
@@ -130,3 +130,10 @@ def test_variables_item_is_deletable(dummy_inventory: _DummyInventory):
     assert "hdfs_property" not in variable_manager.get_vars(
         host=inventory.get_host("master01")
     )
+
+
+def test_skip_if_file_not_writable(dummy_inventory: _DummyInventory):
+    (loader, inventory, variable_manager, hdfs_vars) = dummy_inventory
+
+    with Variables(hdfs_vars).open("r"):
+        pass

--- a/tdp/core/variables/variables.py
+++ b/tdp/core/variables/variables.py
@@ -118,7 +118,7 @@ class _VariablesIOWrapper(VariablesDict):
         return proxy(self)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._close()
+        self.close()
 
     def _flush_on_disk(self) -> None:
         """Write the content of the variables file on disk.
@@ -146,7 +146,7 @@ class _VariablesIOWrapper(VariablesDict):
         # https://docs.python.org/3/library/os.html#os.fsync
         os.fsync(self._file_descriptor.fileno())
 
-    def _close(self) -> None:
+    def close(self) -> None:
         """Closes the file descriptor.
 
         Raises:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

IMO it makes more sense to check if the file is writable before flushing on disk.

Flushing on disk on a non writable file should raise an error.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
