### PR TITLE
`ServiceVariables`: merge variables importation logic

### DIFF
--- a/tdp/core/variables/cluster_variables.py
+++ b/tdp/core/variables/cluster_variables.py
@@ -116,8 +116,9 @@ class ClusterVariables(Mapping[str, ServiceVariables]):
 
                 if service in services_initialized_by_this_function:
                     try:
-                        service_variables.update_from_variables_folder(
-                            "add variables from " + collection_name, path
+                        service_variables.update_from_dir(
+                            path,
+                            validation_message="add variables from " + collection_name,
                         )
                     except EmptyCommit:
                         logger.warning(

--- a/tdp/core/variables/variables.py
+++ b/tdp/core/variables/variables.py
@@ -26,13 +26,20 @@ class Variables:
             del variables["key1"] # deletes value at key `key1`
     """
 
-    def __init__(self, file_path: PathLike):
+    def __init__(self, file_path: PathLike, /, *, create_if_missing: bool = False):
         """Initializes a Variables instance.
 
         Args:
             file_path: Path to the file.
+            create_if_missing: Whether to create the file if it does not exist.
         """
         self._file_path = Path(file_path)
+        # Create the file if it does not exist
+        if not self._file_path.exists():
+            if not create_if_missing:
+                raise FileNotFoundError(f"'{file_path}' does not exist.")
+            self._file_path.parent.mkdir(parents=True, exist_ok=True)
+            self._file_path.touch()
 
     def open(self, mode: Optional[str] = None) -> "_VariablesIOWrapper":
         """Opens the file in the given mode.
@@ -114,7 +121,7 @@ class _VariablesIOWrapper(VariablesDict):
         self._content = from_yaml(self._file_descriptor) or {}
         self._name = path.name
 
-    def __enter__(self):
+    def __enter__(self) -> "_VariablesIOWrapper":
         return proxy(self)
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

Simplifies the import of variables which was split accros multiple methods that were not reused. Current version feels a bit over-engineered, probably because at first we wanted to expose some public API with `tdp-lib`.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
