### PR TITLE
`ServiceVariables`: do not store service schema

### DIFF
--- a/tdp/core/variables/cluster_variables.py
+++ b/tdp/core/variables/cluster_variables.py
@@ -103,8 +103,8 @@ class ClusterVariables(Mapping[str, ServiceVariables]):
                     service_variables = cluster_variables[service]
                 else:
                     repo = repository_class.init(service_tdp_vars)
-                    schemas = collections.get_service_schema(service)
-                    service_variables = ServiceVariables(repo, schemas)
+                    collections.get_service_schema(service)
+                    service_variables = ServiceVariables(repo)
                     cluster_variables[service] = service_variables
 
                 try:
@@ -127,7 +127,7 @@ class ClusterVariables(Mapping[str, ServiceVariables]):
 
         cluster_variables = ClusterVariables(cluster_variables)
         if validate:
-            cluster_variables._validate_services_schemas()
+            cluster_variables._validate_services_schemas(collections)
 
         return cluster_variables
 
@@ -155,20 +155,20 @@ class ClusterVariables(Mapping[str, ServiceVariables]):
         for path in tdp_vars.iterdir():
             if path.is_dir():
                 repo = repository_class(tdp_vars / path.name)
-                schemas = collections.get_service_schema(path.stem)
-                cluster_variables[path.name] = ServiceVariables(repo, schemas)
+                cluster_variables[path.name] = ServiceVariables(repo)
 
         cluster_variables = ClusterVariables(cluster_variables)
 
         if validate:
-            cluster_variables._validate_services_schemas()
+            cluster_variables._validate_services_schemas(collections)
 
         return cluster_variables
 
-    def _validate_services_schemas(self):
+    def _validate_services_schemas(self, collections: Collections):
         """Validate all services schemas."""
         for service in self.values():
-            service.validate()
+            schema = collections.get_service_schema(service.name)
+            service.validate(schema)
 
     def get_modified_sch(
         self,

--- a/tdp/core/variables/service_variables.py
+++ b/tdp/core/variables/service_variables.py
@@ -10,7 +10,7 @@ from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tdp.core.constants import SERVICE_NAME_MAX_LENGTH, YML_EXTENSION
+from tdp.core.constants import YML_EXTENSION
 from tdp.core.types import PathLike
 from tdp.core.variables.schema import validate_against_schema
 from tdp.core.variables.variables import (
@@ -29,22 +29,16 @@ logger = logging.getLogger(__name__)
 class ServiceVariables:
     """Variables of a service."""
 
-    def __init__(self, repository: Repository, schema: dict):
+    def __init__(self, repository: Repository):
         """Initialize a ServiceVariables object.
 
         Args:
-            service_name: Service name.
             repository: Repository of the service.
-            schema: Schema for the service.
 
         Raises:
             ValueError: If the service name is longer than SERVICE_NAME_MAX_LENGTH.
         """
         self._repo = repository
-        # Check that the service name is not too long
-        if len(self.name) > SERVICE_NAME_MAX_LENGTH:
-            raise ValueError(f"{self.name} is longer than {SERVICE_NAME_MAX_LENGTH}")
-        self._schema = schema
 
     @property
     def name(self) -> str:
@@ -55,11 +49,6 @@ class ServiceVariables:
     def repository(self) -> Repository:
         """Repository of the service."""
         return self._repo
-
-    @property
-    def schema(self) -> dict:
-        """Schema of the service."""
-        return self._schema
 
     @property
     def version(self) -> str:
@@ -177,7 +166,7 @@ class ServiceVariables:
             commit=version, path=service_component.service_name + YML_EXTENSION
         )
 
-    def validate(self) -> None:
+    def validate(self, schema: dict) -> None:
         """Validates the service variables against the schema.
 
         Raises:
@@ -197,5 +186,5 @@ class ServiceVariables:
                         service_variables.copy(), variables.name
                     )
                     test_variables.merge(variables)
-            validate_against_schema(test_variables, self.schema)
+            validate_against_schema(test_variables, schema)
         logger.debug(f"Service {self.name} is valid")


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

There is no need to store the schema in the `ServiceVariables` class. It can be retrieve from the collections object and passed as an argument when needed.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
