### PR TITLE
feat: added query returning the running deployment and the operation record by operation order

### DIFF
--- a/tdp/cli/queries.py
+++ b/tdp/cli/queries.py
@@ -447,6 +447,30 @@ def get_planned_deployment(session: Session) -> Optional[DeploymentModel]:
     return session.query(DeploymentModel).filter_by(state="PLANNED").one_or_none()
 
 
+def get_running_deployment(session: Session) -> Optional[DeploymentModel]:
+    """Get the running deployment
+
+    Args:
+        session: The database session.
+
+    Returns:
+        The running deployment or NoResultFound if there is no running deployment.
+
+    Raises:
+        NoResultFound: If there is no running deployment.
+    """
+    try:
+        return (
+            session.query(DeploymentModel)
+            .where(DeploymentModel.state == "Running")
+            .order_by(DeploymentModel.id.desc())
+            .limit(1)
+            .one()
+        )
+    except NoResultFound as e:
+        raise Exception("No running deployment.") from e
+
+
 def get_operation_records(
     session: Session, deployment_id: int, operation_name: str
 ) -> list[OperationModel]:

--- a/tdp/cli/queries.py
+++ b/tdp/cli/queries.py
@@ -474,7 +474,7 @@ def get_running_deployment(session: Session) -> Optional[DeploymentModel]:
 def get_operation_records(
     session: Session, deployment_id: int, operation_name: str
 ) -> list[OperationModel]:
-    """Get an operation records.
+    """Get the records of an operation.
 
     Args:
         session: The database session.
@@ -496,4 +496,32 @@ def get_operation_records(
     except NoResultFound as e:
         raise Exception(
             f"Operation {operation_name} does not exist in deployment {deployment_id}."
+        ) from e
+
+
+def get_operation_from_order(
+    session: Session, deployment_id: int, operation_order: int
+) -> OperationModel:
+    """Get an operation from the order.
+
+    Args:
+        session: The database session.
+        deployment_id: The deployment ID.
+        operation_order: The operation order.
+
+    Returns:
+        The matching operation record.
+
+    Raises:
+        NoResultFound: If the operation order does not exist.
+    """
+    try:
+        return (
+            session.query(OperationModel)
+            .filter_by(deployment_id=deployment_id, operation_order=operation_order)
+            .one()
+        )
+    except NoResultFound as e:
+        raise Exception(
+            f"Operation {operation_order} does not exist in deployment {deployment_id}."
         ) from e


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #538 

#### Additional comments

- Added a query that returns the running deployment if it exists. This query will be used for an endpoint of TDP server.
- Added a query that returns the matching operation record by operation order and deployment id.

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
