### PR TITLE
Refactor/collections init operations

### DIFF
--- a/tdp/core/collections.py
+++ b/tdp/core/collections.py
@@ -172,7 +172,9 @@ class Collections(Mapping[str, Collection]):
                         )
                         # 'restart' and 'stop' operations are not defined in the DAG for
                         # noop, they need to be generated from the start operations.
-                        if read_operation.noop and "_start" in read_operation.name:
+                        if read_operation.noop and read_operation.name.endswith(
+                            "_start"
+                        ):
                             logger.debug(
                                 f"DAG Operation '{read_operation.name}' is noop, "
                                 f"creating the associated restart and stop operations."

--- a/tdp/core/collections.py
+++ b/tdp/core/collections.py
@@ -144,7 +144,7 @@ class Collections(Mapping[str, Collection]):
         other_operations: dict[str, Operation] = {}
 
         # Init DAG Operations
-        for collection_name, collection in collections.items():
+        for collection in collections.values():
             for dag_file in collection.dag_yamls:
                 for read_operation in read_tdp_lib_dag_file(dag_file):
                     if read_operation.name in dag_operations:
@@ -152,7 +152,7 @@ class Collections(Mapping[str, Collection]):
                         logger.debug(
                             f"DAG Operation '{read_operation.name}' defined in collection "
                             f"'{dag_operations[read_operation.name].collection_name}' "
-                            f"is merged with collection '{collection_name}'"
+                            f"is merged with collection '{collection.name}'"
                         )
                         dag_operations[read_operation.name].depends_on.extend(
                             read_operation.depends_on
@@ -162,7 +162,7 @@ class Collections(Mapping[str, Collection]):
                     # Create the operation
                     dag_operations[read_operation.name] = Operation(
                         name=read_operation.name,
-                        collection_name=collection_name,  # TODO: this is the collection that defines the DAG where the operation is defined, not the collection that defines the operation
+                        collection_name=collection.name,  # TODO: this is the collection that defines the DAG where the operation is defined, not the collection that defines the operation
                         depends_on=read_operation.depends_on,
                         noop=read_operation.noop,
                         host_names=(
@@ -202,7 +202,7 @@ class Collections(Mapping[str, Collection]):
                         )
 
         # Init Operations not in the DAG
-        for collection_name, collection in collections.items():
+        for collection in collections.values():
             for operation_name, _ in collection.playbooks.items():
                 if operation_name in dag_operations:
                     continue
@@ -210,13 +210,13 @@ class Collections(Mapping[str, Collection]):
                     logger.info(
                         f"Operation '{operation_name}' defined in collection "
                         f"'{other_operations[operation_name].collection_name}' "
-                        f"is overridden by collection '{collection_name}'"
+                        f"is overridden by collection '{collection.name}'"
                     )
 
                 other_operations[operation_name] = Operation(
                     name=operation_name,
                     host_names=collection.get_hosts_from_playbook(operation_name),
-                    collection_name=collection_name,
+                    collection_name=collection.name,
                 )
 
         return dag_operations, other_operations

--- a/tdp/core/models/test_deployment_log.py
+++ b/tdp/core/models/test_deployment_log.py
@@ -148,8 +148,7 @@ class TestFromOperations:
             ]
         }
         generate_collection_at_path(collection_path, dag_service_operations, {})
-        collection = Collection.from_path(collection_path)
-        collection._inventory_reader = MockInventoryReader(hosts)
+        collection = Collection(collection_path, MockInventoryReader(hosts))
         collections = Collections.from_collection_list([collection])
 
         deployment = DeploymentModel.from_operations(


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

This PR addresses the issue with assigning `collection_name` values. Previously, the assigned `collection_name` was that of the first collection in which the operation was specified in the DAG. Now, the `collection_name` for a playbook is the one in which the playbook is defined.

Another key benefit of this PR is the decoupling of the `Operation` creation logic. Playbook operations are now exclusively forged within `Collection`, and `Collections` is limited to forging Noop operations only.

I've intentionally broken down the PR into numerous commits to ease the review process. The most significant logic change is found in the "refactor: create playbook operations in Collection" commit.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
