### PR TITLE
513 prevent overriding existing plan

### DIFF
--- a/tdp/cli/commands/plan/dag.py
+++ b/tdp/cli/commands/plan/dag.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import click
 
 from tdp.cli.params import collections_option, database_dsn_option
-from tdp.cli.params.plan import preview_option, rolling_interval_option
+from tdp.cli.params.plan import force_option, preview_option, rolling_interval_option
 from tdp.cli.queries import get_planned_deployment
 from tdp.cli.utils import print_deployment
 from tdp.core.dag import Dag
@@ -69,6 +69,7 @@ def _validate_filtertype(
 )
 @rolling_interval_option
 @preview_option
+@force_option
 @collections_option
 @database_dsn_option
 def dag(
@@ -76,6 +77,7 @@ def dag(
     targets: tuple[str],
     restart: bool,
     preview: bool,
+    force: bool,
     collections: Collections,
     database_dsn: str,
     reverse: bool,
@@ -120,7 +122,7 @@ def dag(
     with Dao(database_dsn, commit_on_exit=True) as dao:
         planned_deployment = get_planned_deployment(dao.session)
         if planned_deployment:
-            if click.confirm(
+            if force or click.confirm(
                 "A deployment plan already exists, do you want to override it?"
             ):
                 deployment.id = planned_deployment.id

--- a/tdp/cli/commands/plan/dag.py
+++ b/tdp/cli/commands/plan/dag.py
@@ -120,6 +120,12 @@ def dag(
     with Dao(database_dsn, commit_on_exit=True) as dao:
         planned_deployment = get_planned_deployment(dao.session)
         if planned_deployment:
-            deployment.id = planned_deployment.id
+            if click.confirm(
+                "A deployment plan already exists, do you want to override it?"
+            ):
+                deployment.id = planned_deployment.id
+            else:
+                click.echo("No new deployment plan has been created.")
+                return
         dao.session.merge(deployment)
     click.echo("Deployment plan successfully created.")

--- a/tdp/cli/commands/plan/import_file.py
+++ b/tdp/cli/commands/plan/import_file.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import click
 
 from tdp.cli.params import collections_option, database_dsn_option
+from tdp.cli.params.plan import force_option
 from tdp.cli.queries import get_planned_deployment
 from tdp.cli.utils import parse_file
 from tdp.core.models.deployment_model import DeploymentModel
@@ -22,12 +23,14 @@ logger = logging.getLogger(__name__)
 
 @click.command("import")
 @click.argument("file_name", nargs=1, required=True)
+@force_option
 @collections_option
 @database_dsn_option
 def import_file(
     collections: Collections,
     database_dsn: str,
     file_name: str,
+    force: bool,
 ):
     """Import a deployment from a file."""
     with Dao(database_dsn, commit_on_exit=True) as dao:
@@ -43,7 +46,7 @@ def import_file(
             )
             # if a planned deployment is present, update it instead of creating it
             if planned_deployment:
-                if click.confirm(
+                if force or click.confirm(
                     "A deployment plan already exists, do you want to override it?"
                 ):
                     deployment.id = planned_deployment.id

--- a/tdp/cli/commands/plan/import_file.py
+++ b/tdp/cli/commands/plan/import_file.py
@@ -43,7 +43,13 @@ def import_file(
             )
             # if a planned deployment is present, update it instead of creating it
             if planned_deployment:
-                deployment.id = planned_deployment.id
+                if click.confirm(
+                    "A deployment plan already exists, do you want to override it?"
+                ):
+                    deployment.id = planned_deployment.id
+                else:
+                    click.echo("No new deployment plan has been created.")
+                    return
             dao.session.merge(deployment)
             dao.session.commit()
             click.echo("Deployment plan successfully imported.")

--- a/tdp/cli/commands/plan/ops.py
+++ b/tdp/cli/commands/plan/ops.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import click
 
 from tdp.cli.params import collections_option, database_dsn_option, hosts_option
-from tdp.cli.params.plan import preview_option, rolling_interval_option
+from tdp.cli.params.plan import force_option, preview_option, rolling_interval_option
 from tdp.cli.queries import get_planned_deployment
 from tdp.cli.utils import (
     print_deployment,
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 @collections_option
 @database_dsn_option
 @preview_option
+@force_option
 @rolling_interval_option
 def ops(
     operation_names: tuple[str],
@@ -42,6 +43,7 @@ def ops(
     collections: Collections,
     database_dsn: str,
     preview: bool,
+    force: bool,
     rolling_interval: Optional[int] = None,
 ):
     """Run a list of operations."""
@@ -57,7 +59,7 @@ def ops(
     with Dao(database_dsn, commit_on_exit=True) as dao:
         planned_deployment = get_planned_deployment(dao.session)
         if planned_deployment:
-            if click.confirm(
+            if force or click.confirm(
                 "A deployment plan already exists, do you want to override it?"
             ):
                 deployment.id = planned_deployment.id

--- a/tdp/cli/commands/plan/ops.py
+++ b/tdp/cli/commands/plan/ops.py
@@ -57,6 +57,12 @@ def ops(
     with Dao(database_dsn, commit_on_exit=True) as dao:
         planned_deployment = get_planned_deployment(dao.session)
         if planned_deployment:
-            deployment.id = planned_deployment.id
+            if click.confirm(
+                "A deployment plan already exists, do you want to override it?"
+            ):
+                deployment.id = planned_deployment.id
+            else:
+                click.echo("No new deployment plan has been created.")
+                return
         dao.session.merge(deployment)
     click.echo("Deployment plan successfully created.")

--- a/tdp/cli/commands/plan/reconfigure.py
+++ b/tdp/cli/commands/plan/reconfigure.py
@@ -44,6 +44,12 @@ def reconfigure(
             return
         planned_deployment = get_planned_deployment(dao.session)
         if planned_deployment:
-            deployment.id = planned_deployment.id
+            if click.confirm(
+                "A deployment plan already exists, do you want to override it?"
+            ):
+                deployment.id = planned_deployment.id
+            else:
+                click.echo("No new deployment plan has been created.")
+                return
         dao.session.merge(deployment)
     click.echo("Deployment plan successfully created.")

--- a/tdp/cli/commands/plan/reconfigure.py
+++ b/tdp/cli/commands/plan/reconfigure.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import click
 
 from tdp.cli.params import collections_option, database_dsn_option
-from tdp.cli.params.plan import preview_option, rolling_interval_option
+from tdp.cli.params.plan import force_option, preview_option, rolling_interval_option
 from tdp.cli.queries import get_planned_deployment
 from tdp.cli.utils import (
     print_deployment,
@@ -24,11 +24,13 @@ if TYPE_CHECKING:
 @collections_option
 @database_dsn_option
 @preview_option
+@force_option
 @rolling_interval_option
 def reconfigure(
     collections: Collections,
     database_dsn: str,
     preview: bool,
+    force: bool,
     rolling_interval: Optional[int] = None,
 ):
     """Reconfigure required TDP services."""
@@ -44,7 +46,7 @@ def reconfigure(
             return
         planned_deployment = get_planned_deployment(dao.session)
         if planned_deployment:
-            if click.confirm(
+            if force or click.confirm(
                 "A deployment plan already exists, do you want to override it?"
             ):
                 deployment.id = planned_deployment.id

--- a/tdp/cli/params/plan/__init__.py
+++ b/tdp/cli/params/plan/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
+from .force_option import force_option
 from .preview_option import preview_option
 from .rolling_interval_option import rolling_interval_option

--- a/tdp/cli/params/plan/force_option.py
+++ b/tdp/cli/params/plan/force_option.py
@@ -1,0 +1,17 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+import click
+from click.decorators import FC
+
+
+def force_option(func: FC) -> FC:
+    """Click option that adds a force option to the command.
+
+    The option is a flag.
+    """
+    return click.option(
+        "--force",
+        is_flag=True,
+        help="Force overriding an existing deployment plan.",
+    )(func)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #513 

#### Additional comments

- Added `y/N` confirmation to override existing deployment plan in plan dag, reconfigure, import and ops.
- Added `--force` option to automatically override existing deployment plan without asking the question.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
