### PR TITLE
Initialize `Playbook` entities inside of `Collection`

### DIFF
--- a/tdp/core/collection.py
+++ b/tdp/core/collection.py
@@ -36,10 +36,6 @@ class MissingMandatoryDirectoryError(Exception):
     pass
 
 
-class MissingPlaybookError(Exception):
-    pass
-
-
 class Collection:
     """An enriched version of an Ansible collection.
 
@@ -150,19 +146,6 @@ class Collection:
             return {}
         with schema_path.open() as fd:
             return json.load(fd)
-
-    def get_hosts_from_playbook(self, playbook: str) -> set[str]:
-        """Get the set of hosts for a playbook.
-
-        Args:
-            playbook: Playbook name without extension.
-
-        Returns:
-            Set of hosts.
-        """
-        if playbook not in self.playbooks:
-            raise MissingPlaybookError(f"Playbook {playbook} not found.")
-        return self.playbooks[playbook].hosts
 
     def _check_path(self):
         """Validate the collection path content."""

--- a/tdp/core/collection.py
+++ b/tdp/core/collection.py
@@ -163,12 +163,9 @@ class Collection:
         """
         if playbook not in self.playbooks:
             raise MissingPlaybookError(f"Playbook {playbook} not found.")
-        try:
-            return self._inventory_reader.get_hosts_from_playbook(
-                self.playbooks[playbook].open()
-            )
-        except Exception as e:
-            raise ValueError(f"Can't parse playbook {self.playbooks[playbook]}.") from e
+        return read_hosts_from_playbook(
+            self.playbooks[playbook], self._inventory_reader
+        )
 
     def _check_path(self):
         """Validate the collection path content."""
@@ -182,3 +179,24 @@ class Collection:
                 raise MissingMandatoryDirectoryError(
                     f"{self._path} does not contain the mandatory directory {mandatory_directory}.",
                 )
+
+
+def read_hosts_from_playbook(
+    playbook_path: Path, inventory_reader: Optional[InventoryReader]
+) -> set[str]:
+    """Read the hosts from a playbook.
+
+    Args:
+        playbook_path: Path to the playbook.
+        inventory_reader: Inventory reader.
+
+    Returns:
+        Set of hosts.
+    """
+    if not inventory_reader:
+        inventory_reader = InventoryReader()
+    try:
+        with playbook_path.open() as fd:
+            return inventory_reader.get_hosts_from_playbook(fd)
+    except Exception as e:
+        raise ValueError(f"Can't parse playbook {playbook_path}.") from e

--- a/tdp/core/collections.py
+++ b/tdp/core/collections.py
@@ -151,14 +151,12 @@ class Collections(Mapping[str, Collection]):
 
                     # The read_operation is associated with a playbook defined in the
                     # current collection
-                    if _ := collection.playbooks.get(read_operation.name):
+                    if playbook := collection.playbooks.get(read_operation.name):
                         # TODO: would be nice to dissociate the Operation class from the playbook and store the playbook in the Operation
                         dag_operation_to_register = Operation(
                             name=read_operation.name,
                             collection_name=collection.name,
-                            host_names=collection.get_hosts_from_playbook(
-                                read_operation.name
-                            ),
+                            host_names=playbook.hosts,  # TODO: do not store the hosts in the Operation object
                             depends_on=read_operation.depends_on.copy(),
                         )
                         # If the operation is already registered, merge its dependencies
@@ -234,7 +232,7 @@ class Collections(Mapping[str, Collection]):
         for collection in collections.values():
             # Load playbook operations to complete the operations list with the
             # operations that are not defined in the DAG files
-            for operation_name in collection.playbooks:
+            for operation_name, playbook in collection.playbooks.items():
                 if operation_name in dag_operations:
                     continue
                 if operation_name in other_operations:
@@ -245,7 +243,7 @@ class Collections(Mapping[str, Collection]):
                     )
                 other_operations[operation_name] = Operation(
                     name=operation_name,
-                    host_names=collection.get_hosts_from_playbook(operation_name),
+                    host_names=playbook.hosts,  # TODO: do not store the hosts in the Operation object
                     collection_name=collection.name,
                 )
 

--- a/tdp/core/deployment/deployment_runner.py
+++ b/tdp/core/deployment/deployment_runner.py
@@ -66,9 +66,9 @@ class DeploymentRunner:
             return
 
         # Execute the operation
-        playbook_file = self._collections[operation.collection_name].playbooks[
-            operation.name
-        ]
+        playbook_file = (
+            self._collections[operation.collection_name].playbooks[operation.name].path
+        )
         state, logs = self._executor.execute(
             playbook=playbook_file,
             host=operation_rec.host,

--- a/tdp/core/deployment/executor.py
+++ b/tdp/core/deployment/executor.py
@@ -5,6 +5,7 @@ import io
 import logging
 import subprocess
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Optional
 
 from tdp.core.models import OperationStateEnum
@@ -77,7 +78,7 @@ class Executor:
 
     def execute(
         self,
-        playbook: str,
+        playbook: Path,
         host: Optional[str] = None,
         extra_vars: Optional[Iterable[str]] = None,
     ) -> tuple[OperationStateEnum, bytes]:

--- a/tdp/core/entities/operation.py
+++ b/tdp/core/entities/operation.py
@@ -1,0 +1,22 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from tdp.core.constants import HOST_NAME_MAX_LENGTH
+
+
+@dataclass(frozen=True)
+class Playbook:
+    path: Path
+    collection_name: str
+    hosts: set[str]  # TODO: would be better to use a frozenset
+
+    def __post_init__(self):
+        for host_name in self.hosts:
+            if len(host_name) > HOST_NAME_MAX_LENGTH:
+                raise ValueError(
+                    f"Host '{host_name}' must be less than {HOST_NAME_MAX_LENGTH} "
+                    "characters."
+                )

--- a/tdp/core/entities/test_operation.py
+++ b/tdp/core/entities/test_operation.py
@@ -1,0 +1,31 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from tdp.core.constants import HOST_NAME_MAX_LENGTH
+from tdp.core.entities.operation import Playbook
+
+
+def test_playbook_creation(tmp_path: Path):
+    path = tmp_path / "playbook.yml"
+    collection_name = "my_collection"
+    hosts = {"host1", "host2", "host3"}
+
+    playbook = Playbook(path=path, collection_name=collection_name, hosts=hosts)
+
+    assert playbook.path == path
+    assert playbook.collection_name == collection_name
+    assert playbook.hosts == hosts
+
+
+def test_playbook_creation_with_long_host_name(tmp_path: Path):
+    path = tmp_path / "playbook.yml"
+    collection_name = "my_collection"
+    long_host_name = "a" * (HOST_NAME_MAX_LENGTH + 1)
+    hosts = {"host1", "host2", long_host_name}
+
+    with pytest.raises(ValueError):
+        Playbook(path=path, collection_name=collection_name, hosts=hosts)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Change the `Collection.playbooks` properties so that it maps operation names to `Playbook` object instead of playbook Paths.

In another PR, we should remove hosts from `Operation` definition so that host are only stored in `Playbook`.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
