### PR TITLE
refactor: deleted check_operations_exist function

### DIFF
--- a/tdp/core/collections.py
+++ b/tdp/core/collections.py
@@ -309,22 +309,6 @@ class Collections(Mapping[str, Collection]):
                 f"Operation {operation_name} not found in collections."
             )
 
-    # TODO: remove and use check_operation_exists in a loop
-    def check_operations_exist(self, operations_names: Iterable[str]) -> None:
-        """Check that all operations exist.
-
-        Args:
-            operations_names: List of operation names to check.
-
-        Raises:
-            MissingOperationError: If an operation is missing.
-        """
-        for operation_name in operations_names:
-            if operation_name not in self.operations:
-                raise MissingOperationError(
-                    f"Operation {operation_name} not found in collections."
-                )
-
     def check_operations_hosts_exist(
         self, operation_names: Iterable[str], host_names: Iterable[str]
     ) -> None:

--- a/tdp/core/models/deployment_model.py
+++ b/tdp/core/models/deployment_model.py
@@ -292,8 +292,8 @@ class DeploymentModel(BaseModel):
                     [host_name],
                 )
             else:
-                collections.check_operations_exist(
-                    [operation_name],
+                collections.check_operation_exists(
+                    operation_name,
                 )
 
             deployment.operations.append(
@@ -433,7 +433,8 @@ class DeploymentModel(BaseModel):
             for operation in failed_deployment.operations[failed_operation_id:]
         ]
         operations_names_to_resume = [i[0] for i in operations_tuple_to_resume]
-        collections.check_operations_exist(operations_names_to_resume)
+        for operation_name_to_resume in operations_names_to_resume:
+            collections.check_operation_exists(operation_name_to_resume)
         deployment = DeploymentModel(
             deployment_type=DeploymentTypeEnum.RESUME,
             options={


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

Deleted the function `check_operations_exist` in `collections` since the a function called `check_operation_exists` already exists and can be looped to achieve the same.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
