### PR TITLE
suppressed get_variables function in ServiceVariables

### DIFF
--- a/tdp/core/variables/service_variables.py
+++ b/tdp/core/variables/service_variables.py
@@ -78,8 +78,7 @@ class ServiceVariables:
         """Path of the service repository."""
         return self.repository.path
 
-    # TODO: rename to `get_component_variables`
-    def get_variables(self, component_name: str) -> dict:
+    def get_component_variables(self, component_name: str) -> dict | None:
         """Get the variables for a component.
 
         Args:

--- a/tdp/core/variables/service_variables.py
+++ b/tdp/core/variables/service_variables.py
@@ -78,21 +78,6 @@ class ServiceVariables:
         """Path of the service repository."""
         return self.repository.path
 
-    def get_component_variables(self, component_name: str) -> dict | None:
-        """Get the variables for a component.
-
-        Args:
-            component_name: Name of the component.
-
-        Returns:
-            Copy of the variables of the component.
-        """
-        component_path = self._repo.path / (component_name + YML_EXTENSION)
-        if not component_path.exists():
-            return None
-        with Variables(component_path).open("r") as variables:
-            return variables.copy()
-
     def update_from_dir(
         self, input_dir: PathLike, /, *, validation_message: str
     ) -> None:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Renamed the `get_variables` function in class `ServiceVariables` to `get_component_variables` which fits more its goal. The function is not currently used in TDP-lib, however it will very probably be used in the upcoming TDP-server in the endpoint `/api/v1/variables/{service_id}/components/{component_id}`.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
