### PR TITLE
Stephan/feat/test databases framework

### DIFF
--- a/tdp/cli/commands/conftest.py
+++ b/tdp/cli/commands/conftest.py
@@ -29,10 +29,5 @@ def collection_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture
-def database_dsn(tmp_path: Path) -> str:
-    return "sqlite:///" + str(tmp_path / "sqlite.db")
-
-
-@pytest.fixture
 def vars(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return tmp_path_factory.mktemp("collection")

--- a/tdp/cli/commands/plan/test_dag.py
+++ b/tdp/cli/commands/plan/test_dag.py
@@ -10,12 +10,12 @@ from tdp.cli.commands.init import init
 from tdp.cli.commands.plan.dag import dag
 
 
-def test_tdp_plan_dag(collection_path: Path, database_dsn: str, vars: Path):
+def test_tdp_plan_dag(collection_path: Path, db_dsn: str, vars: Path):
     base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
     ]
     runner = CliRunner()
     result = runner.invoke(init, [*base_args, "--vars", str(vars)])

--- a/tdp/cli/commands/plan/test_ops.py
+++ b/tdp/cli/commands/plan/test_ops.py
@@ -9,12 +9,12 @@ from tdp.cli.commands.init import init
 from tdp.cli.commands.plan.ops import ops
 
 
-def test_tdp_plan_run(collection_path: Path, database_dsn: str, vars: Path):
+def test_tdp_plan_run(collection_path: Path, db_dsn: str, vars: Path):
     base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
     ]
     runner = CliRunner()
     result = runner.invoke(init, [*base_args, "--vars", str(vars)])

--- a/tdp/cli/commands/plan/test_reconfigure.py
+++ b/tdp/cli/commands/plan/test_reconfigure.py
@@ -9,12 +9,12 @@ from tdp.cli.commands.init import init
 from tdp.cli.commands.plan.reconfigure import reconfigure
 
 
-def test_tdp_plan_reconfigure(collection_path: Path, database_dsn: str, vars: Path):
+def test_tdp_plan_reconfigure(collection_path: Path, db_dsn: str, vars: Path):
     base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
     ]
     runner = CliRunner()
     result = runner.invoke(init, [*base_args, "--vars", str(vars)])

--- a/tdp/cli/commands/plan/test_resume.py
+++ b/tdp/cli/commands/plan/test_resume.py
@@ -11,13 +11,13 @@ from tdp.cli.commands.plan.resume import resume
 
 
 def test_tdp_plan_resume_nothing_to_resume(
-    collection_path: Path, database_dsn: str, vars: Path
+    collection_path: Path, db_dsn: str, vars: Path
 ):
     base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
     ]
     runner = CliRunner()
     result = runner.invoke(init, [*base_args, "--vars", str(vars)])

--- a/tdp/cli/commands/status/test_edit.py
+++ b/tdp/cli/commands/status/test_edit.py
@@ -9,12 +9,12 @@ from tdp.cli.commands.init import init
 from tdp.cli.commands.status.edit import edit
 
 
-def test_tdp_status_edit(collection_path: Path, database_dsn: str, vars: Path):
+def test_tdp_status_edit(collection_path: Path, db_dsn: str, vars: Path):
     base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
         "--vars",
         str(vars),
     ]

--- a/tdp/cli/commands/status/test_generate_stales.py
+++ b/tdp/cli/commands/status/test_generate_stales.py
@@ -9,12 +9,12 @@ from tdp.cli.commands.init import init
 from tdp.cli.commands.status.generate_stales import generate_stales
 
 
-def test_tdp_status_edit(collection_path: Path, database_dsn: str, vars: Path):
+def test_tdp_status_edit(collection_path: Path, db_dsn: str, vars: Path):
     base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
         "--vars",
         str(vars),
     ]

--- a/tdp/cli/commands/status/test_show.py
+++ b/tdp/cli/commands/status/test_show.py
@@ -9,12 +9,12 @@ from tdp.cli.commands.init import init
 from tdp.cli.commands.status.show import show
 
 
-def test_tdp_status_edit(collection_path: Path, database_dsn: str, vars: Path):
+def test_tdp_status_edit(collection_path: Path, db_dsn: str, vars: Path):
     base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
         "--vars",
         str(vars),
     ]

--- a/tdp/cli/commands/test_deploy.py
+++ b/tdp/cli/commands/test_deploy.py
@@ -11,13 +11,13 @@ from tdp.cli.commands.plan.dag import dag
 
 
 def test_tdp_deploy_mock(
-    collection_path: Path, database_dsn: str, vars: Path, tmp_path: Path
+    collection_path: Path, db_dsn: str, vars: Path, tmp_path: Path
 ):
     base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
     ]
     runner = CliRunner()
     result = runner.invoke(init, [*base_args, "--vars", str(vars)])

--- a/tdp/cli/commands/test_init.py
+++ b/tdp/cli/commands/test_init.py
@@ -9,12 +9,12 @@ from click.testing import CliRunner
 from tdp.cli.commands.init import init
 
 
-def test_tdp_init(collection_path: Path, database_dsn: str, vars: Path):
+def test_tdp_init(collection_path: Path, db_dsn: str, vars: Path):
     args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
-        database_dsn,
+        db_dsn,
         "--vars",
         vars,
     ]

--- a/tdp/cli/test_get_sch_status.py
+++ b/tdp/cli/test_get_sch_status.py
@@ -7,8 +7,9 @@ import string
 from typing import List, Optional
 
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy.engine import Engine
 
+from tdp.conftest import create_session
 from tdp.core.models import (
     SCHStatusLogModel,
     SCHStatusLogSourceEnum,
@@ -97,22 +98,24 @@ def _last_values(
 
 
 @pytest.mark.skip(reason="db_session fixture needs to be reworked.")
-def test_single_service_component_status(db_session: Session):
+def test_single_service_component_status(db_engine_initialized: Engine):
     """Test the get_sch_status query with a single sch."""
     logs = _mock_sch_status_log("smock", "cmock", "hmock", 5)
     last_values = _last_values(logs)
 
     # Use this instead of db_session.add_all() to ensure different timestamps
-    for log in logs:
-        db_session.add(log)
-        db_session.commit()
+    with create_session(db_engine_initialized) as session:
+        for log in logs:
+            session.add(log)
+            # Commit at each step to ensure different timestamps
+            session.commit()
 
-    with Dao(db_session) as dao:
+    with Dao(db_engine_initialized) as dao:
         assert dao.get_cluster_status() == [last_values]
 
 
 @pytest.mark.skip(reason="db_session fixture needs to be reworked.")
-def test_multiple_service_component_status(db_session: Session):
+def test_multiple_service_component_status(db_engine_initialized: Engine):
     """Test the get_sch_status query with multiple schs."""
     classic_component_logs = _mock_sch_status_log("smock", "cmock", "hmock")
     service_noop_logs = _mock_sch_status_log("smock", None, None)
@@ -143,11 +146,13 @@ def test_multiple_service_component_status(db_session: Session):
         chosen_index = random.choice(available_indices)
 
         # Append the next log from the chosen list to the database.
-        db_session.add(next_logs[chosen_index])
-        db_session.commit()
+        with create_session(db_engine_initialized) as session:
+            session.add(next_logs[chosen_index])
+            # Commit at each step to ensure different timestamps
+            session.commit()
 
         # Update the next log for the chosen list. 'None' if no more logs are left.
         next_logs[chosen_index] = next(iterators[chosen_index], None)
 
-    with Dao(db_session) as dao:
+    with Dao(db_engine_initialized) as dao:
         assert set(dao.get_cluster_status()) == last_values

--- a/tdp/conftest.py
+++ b/tdp/conftest.py
@@ -18,14 +18,24 @@ from tdp.core.constants import (
 )
 from tdp.core.models import BaseModel
 
-DATABASE_URL = "sqlite:///:memory:"
+
+@pytest.fixture
+def database_dsn(tmp_path: Path) -> str:
+    """Return a database dsn.
+
+    We create a temp path instead of the default in-memory sqlite database as some test
+    need to generate several engine instances (which will loose the data between them).
+    Concerned tests are CLI tests that need to perform a `tdp init` at the beginning of
+    the test.
+    """
+    return "sqlite:///" + str(tmp_path / "sqlite.db")
 
 
 # TODO: This fixture should return a database dsn
 @pytest.fixture()
-def db_session() -> Generator[Session, None, None]:
+def db_session(database_dsn: str) -> Generator[Session, None, None]:
     # Connect to the database
-    engine = create_engine(DATABASE_URL)
+    engine = create_engine(database_dsn)
 
     # Create tables
     BaseModel.metadata.create_all(engine)

--- a/tdp/conftest.py
+++ b/tdp/conftest.py
@@ -64,18 +64,13 @@ def db_dsn(
 
 
 @pytest.fixture()
-def db_engine_uninitialized(db_dsn: str) -> Generator[Engine, None, None]:
-    """Create a database engine."""
+def db_engine(
+    db_dsn: str, request: pytest.FixtureRequest
+) -> Generator[Engine, None, None]:
+    """Create a database engine and optionnally by default initialize the schema."""
     engine = create_engine(db_dsn)
-    yield engine
-    engine.dispose()
-
-
-@pytest.fixture()
-def db_engine_initialized(db_dsn: str) -> Generator[Engine, None, None]:
-    """Create a database engine and initialize the schema."""
-    engine = create_engine(db_dsn)
-    init_database(engine)
+    if request.param:
+        init_database(engine)
     yield engine
     engine.dispose()
 

--- a/tdp/conftest.py
+++ b/tdp/conftest.py
@@ -20,7 +20,7 @@ from tdp.core.models import BaseModel
 
 
 @pytest.fixture
-def database_dsn(tmp_path: Path) -> str:
+def db_dsn(tmp_path: Path) -> str:
     """Return a database dsn.
 
     We create a temp path instead of the default in-memory sqlite database as some test
@@ -33,9 +33,9 @@ def database_dsn(tmp_path: Path) -> str:
 
 # TODO: This fixture should return a database dsn
 @pytest.fixture()
-def db_session(database_dsn: str) -> Generator[Session, None, None]:
+def db_session(db_dsn: str) -> Generator[Session, None, None]:
     # Connect to the database
-    engine = create_engine(database_dsn)
+    engine = create_engine(db_dsn)
 
     # Create tables
     BaseModel.metadata.create_all(engine)

--- a/tdp/core/models/__init__.py
+++ b/tdp/core/models/__init__.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from sqlalchemy import Engine
 from sqlalchemy.engine.row import Row
 
 from tdp.core.models.base_model import BaseModel
@@ -19,5 +20,5 @@ from tdp.core.models.sch_status_log_model import (
 )
 
 
-def init_database(engine):
+def init_database(engine: Engine) -> None:
     BaseModel.metadata.create_all(engine)

--- a/tdp/core/models/test_models.py
+++ b/tdp/core/models/test_models.py
@@ -4,6 +4,7 @@
 import logging
 from datetime import datetime, timedelta
 
+import pytest
 from sqlalchemy.engine import Engine
 
 from tdp.conftest import create_session
@@ -13,7 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: add some status logs
-def test_create_deployment(db_engine_initialized: Engine):
+@pytest.mark.parametrize("db_engine", [True], indirect=True)
+def test_create_deployment(db_engine: Engine):
     deployment = DeploymentModel(
         options={
             "sources": ["source1", "source2"],
@@ -52,7 +54,7 @@ def test_create_deployment(db_engine_initialized: Engine):
     logger.info(operation_rec)
     logger.info(component_version_log)
 
-    with create_session(db_engine_initialized) as session:
+    with create_session(db_engine) as session:
         session.add(deployment)
         session.commit()
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

Modified test framework to perform tests on multiple databases. Tests are always performed by default on SQLite, however other databases can be added with option `--database-dsn`. For instance:

```sh
pytest -v tdp --database-dsn=postgresql://tdp:tdp@localhost:5432/tdp --database-dsn=mysql+pymysql://admin:admin@localhost:3306/tdp
```

where the tests will also be performed on PostgreSQL and MariaDB.

Moreover the test `test_single_service_component_status` in `tdp/cli/test_get_sch_status.py` has been reworked and is now functioning.

There is still the other test `test_multiple_service_component_status` in the same module to be reworked.


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
