### PR TITLE
refactor: engine in test procedure

### DIFF
--- a/tdp/cli/commands/conftest.py
+++ b/tdp/cli/commands/conftest.py
@@ -1,11 +1,37 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import pytest
+from click.testing import CliRunner
+from sqlalchemy import create_engine
 
+from tdp.cli.commands.init import init
 from tdp.conftest import generate_collection_at_path
+from tdp.core.models import BaseModel
+
+
+@pytest.fixture
+def tdp_init(
+    collection_path: Path, db_dsn: str, vars: Path
+) -> Generator[list[Any], Any, None]:
+    base_args = [
+        "--collection-path",
+        collection_path,
+        "--database-dsn",
+        db_dsn,
+        "--vars",
+        vars,
+    ]
+    runner = CliRunner()
+    runner.invoke(init, base_args)
+    yield base_args
+    engine = create_engine(db_dsn)
+    BaseModel.metadata.drop_all(engine)
+    engine.dispose()
 
 
 @pytest.fixture

--- a/tdp/cli/commands/conftest.py
+++ b/tdp/cli/commands/conftest.py
@@ -1,6 +1,7 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
+from collections import namedtuple
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -13,12 +14,14 @@ from tdp.cli.commands.init import init
 from tdp.conftest import generate_collection_at_path
 from tdp.core.models import BaseModel
 
+tdp_init_args = namedtuple("tdp_init_args", ["collection_path", "db_dsn", "vars"])
+
 
 @pytest.fixture
 def tdp_init(
     collection_path: Path, db_dsn: str, vars: Path
-) -> Generator[tuple[Path, str, Path], Any, None]:
-    tdp_init_args = [
+) -> Generator[tdp_init_args, Any, None]:
+    base_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
@@ -27,8 +30,8 @@ def tdp_init(
         vars,
     ]
     runner = CliRunner()
-    runner.invoke(init, tdp_init_args)
-    yield (collection_path, db_dsn, vars)
+    runner.invoke(init, base_args)
+    yield tdp_init_args(collection_path, db_dsn, vars)
     engine = create_engine(db_dsn)
     BaseModel.metadata.drop_all(engine)
     engine.dispose()

--- a/tdp/cli/commands/conftest.py
+++ b/tdp/cli/commands/conftest.py
@@ -17,8 +17,8 @@ from tdp.core.models import BaseModel
 @pytest.fixture
 def tdp_init(
     collection_path: Path, db_dsn: str, vars: Path
-) -> Generator[list[Any], Any, None]:
-    base_args = [
+) -> Generator[tuple[Path, str, Path], Any, None]:
+    tdp_init_args = [
         "--collection-path",
         collection_path,
         "--database-dsn",
@@ -27,8 +27,8 @@ def tdp_init(
         vars,
     ]
     runner = CliRunner()
-    runner.invoke(init, base_args)
-    yield base_args
+    runner.invoke(init, tdp_init_args)
+    yield (collection_path, db_dsn, vars)
     engine = create_engine(db_dsn)
     BaseModel.metadata.drop_all(engine)
     engine.dispose()

--- a/tdp/cli/commands/conftest.py
+++ b/tdp/cli/commands/conftest.py
@@ -1,10 +1,9 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import namedtuple
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any
+from typing import NamedTuple
 
 import pytest
 from click.testing import CliRunner
@@ -14,13 +13,17 @@ from tdp.cli.commands.init import init
 from tdp.conftest import generate_collection_at_path
 from tdp.core.models import BaseModel
 
-tdp_init_args = namedtuple("tdp_init_args", ["collection_path", "db_dsn", "vars"])
+
+class TDPInitArgs(NamedTuple):
+    collection_path: Path
+    db_dsn: str
+    vars: Path
 
 
 @pytest.fixture
 def tdp_init(
     collection_path: Path, db_dsn: str, vars: Path
-) -> Generator[tdp_init_args, Any, None]:
+) -> Generator[TDPInitArgs, None, None]:
     base_args = [
         "--collection-path",
         collection_path,
@@ -31,7 +34,7 @@ def tdp_init(
     ]
     runner = CliRunner()
     runner.invoke(init, base_args)
-    yield tdp_init_args(collection_path, db_dsn, vars)
+    yield TDPInitArgs(collection_path, db_dsn, vars)
     engine = create_engine(db_dsn)
     BaseModel.metadata.drop_all(engine)
     engine.dispose()

--- a/tdp/cli/commands/conftest.py
+++ b/tdp/cli/commands/conftest.py
@@ -26,11 +26,11 @@ def tdp_init(
 ) -> Generator[TDPInitArgs, None, None]:
     base_args = [
         "--collection-path",
-        collection_path,
+        str(collection_path),
         "--database-dsn",
         db_dsn,
         "--vars",
-        vars,
+        str(vars),
     ]
     runner = CliRunner()
     runner.invoke(init, base_args)

--- a/tdp/cli/commands/plan/test_dag.py
+++ b/tdp/cli/commands/plan/test_dag.py
@@ -4,18 +4,19 @@
 
 from click.testing import CliRunner
 
+from tdp.cli.commands.conftest import tdp_init_args
 from tdp.cli.commands.plan.dag import dag
 
 
 def test_tdp_plan_dag(
-    tdp_init: tuple,
+    tdp_init: tdp_init_args,
 ):
-    tdp_init_args = [
+    base_args = [
         "--collection-path",
-        tdp_init[0],
+        tdp_init.collection_path,
         "--database-dsn",
-        tdp_init[1],
+        tdp_init.db_dsn,
     ]
     runner = CliRunner()
-    result = runner.invoke(dag, tdp_init_args)
+    result = runner.invoke(dag, base_args)
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/plan/test_dag.py
+++ b/tdp/cli/commands/plan/test_dag.py
@@ -8,8 +8,14 @@ from tdp.cli.commands.plan.dag import dag
 
 
 def test_tdp_plan_dag(
-    tdp_init: list,
+    tdp_init: tuple,
 ):
+    tdp_init_args = [
+        "--collection-path",
+        tdp_init[0],
+        "--database-dsn",
+        tdp_init[1],
+    ]
     runner = CliRunner()
-    result = runner.invoke(dag, tdp_init[:-2])
+    result = runner.invoke(dag, tdp_init_args)
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/plan/test_dag.py
+++ b/tdp/cli/commands/plan/test_dag.py
@@ -16,7 +16,7 @@ def test_tdp_plan_dag(
         dag,
         [
             "--collection-path",
-            tdp_init.collection_path,
+            str(tdp_init.collection_path),
             "--database-dsn",
             tdp_init.db_dsn,
         ],

--- a/tdp/cli/commands/plan/test_dag.py
+++ b/tdp/cli/commands/plan/test_dag.py
@@ -2,23 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from pathlib import Path
-
 from click.testing import CliRunner
 
-from tdp.cli.commands.init import init
 from tdp.cli.commands.plan.dag import dag
 
 
-def test_tdp_plan_dag(collection_path: Path, db_dsn: str, vars: Path):
-    base_args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-    ]
+def test_tdp_plan_dag(
+    tdp_init: list,
+):
     runner = CliRunner()
-    result = runner.invoke(init, [*base_args, "--vars", str(vars)])
-    assert result.exit_code == 0, result.output
-    result = runner.invoke(dag, base_args)
+    result = runner.invoke(dag, tdp_init[:-2])
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/plan/test_dag.py
+++ b/tdp/cli/commands/plan/test_dag.py
@@ -4,12 +4,12 @@
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.conftest import tdp_init_args
+from tdp.cli.commands.conftest import TDPInitArgs
 from tdp.cli.commands.plan.dag import dag
 
 
 def test_tdp_plan_dag(
-    tdp_init: tdp_init_args,
+    tdp_init: TDPInitArgs,
 ):
     runner = CliRunner()
     result = runner.invoke(

--- a/tdp/cli/commands/plan/test_dag.py
+++ b/tdp/cli/commands/plan/test_dag.py
@@ -11,12 +11,14 @@ from tdp.cli.commands.plan.dag import dag
 def test_tdp_plan_dag(
     tdp_init: tdp_init_args,
 ):
-    base_args = [
-        "--collection-path",
-        tdp_init.collection_path,
-        "--database-dsn",
-        tdp_init.db_dsn,
-    ]
     runner = CliRunner()
-    result = runner.invoke(dag, base_args)
+    result = runner.invoke(
+        dag,
+        [
+            "--collection-path",
+            tdp_init.collection_path,
+            "--database-dsn",
+            tdp_init.db_dsn,
+        ],
+    )
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/plan/test_ops.py
+++ b/tdp/cli/commands/plan/test_ops.py
@@ -4,23 +4,21 @@
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.conftest import tdp_init_args
+from tdp.cli.commands.conftest import TDPInitArgs
 from tdp.cli.commands.plan.ops import ops
 
 
 def test_tdp_plan_run(
-    tdp_init: tdp_init_args,
+    tdp_init: TDPInitArgs,
 ):
     runner = CliRunner()
     result = runner.invoke(
         ops,
         [
-            *[
-                "--collection-path",
-                tdp_init.collection_path,
-                "--database-dsn",
-                tdp_init.db_dsn,
-            ],
+            "--collection-path",
+            tdp_init.collection_path,
+            "--database-dsn",
+            tdp_init.db_dsn,
             "service_install",
         ],
     )

--- a/tdp/cli/commands/plan/test_ops.py
+++ b/tdp/cli/commands/plan/test_ops.py
@@ -11,12 +11,17 @@ from tdp.cli.commands.plan.ops import ops
 def test_tdp_plan_run(
     tdp_init: tdp_init_args,
 ):
-    base_args = [
-        "--collection-path",
-        tdp_init.collection_path,
-        "--database-dsn",
-        tdp_init.db_dsn,
-    ]
     runner = CliRunner()
-    result = runner.invoke(ops, [*base_args, "service_install"])
+    result = runner.invoke(
+        ops,
+        [
+            *[
+                "--collection-path",
+                tdp_init.collection_path,
+                "--database-dsn",
+                tdp_init.db_dsn,
+            ],
+            "service_install",
+        ],
+    )
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/plan/test_ops.py
+++ b/tdp/cli/commands/plan/test_ops.py
@@ -4,18 +4,19 @@
 
 from click.testing import CliRunner
 
+from tdp.cli.commands.conftest import tdp_init_args
 from tdp.cli.commands.plan.ops import ops
 
 
 def test_tdp_plan_run(
-    tdp_init: tuple,
+    tdp_init: tdp_init_args,
 ):
-    tdp_init_args = [
+    base_args = [
         "--collection-path",
-        tdp_init[0],
+        tdp_init.collection_path,
         "--database-dsn",
-        tdp_init[1],
+        tdp_init.db_dsn,
     ]
     runner = CliRunner()
-    result = runner.invoke(ops, [*tdp_init_args, "service_install"])
+    result = runner.invoke(ops, [*base_args, "service_install"])
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/plan/test_ops.py
+++ b/tdp/cli/commands/plan/test_ops.py
@@ -8,8 +8,14 @@ from tdp.cli.commands.plan.ops import ops
 
 
 def test_tdp_plan_run(
-    tdp_init: list,
+    tdp_init: tuple,
 ):
+    tdp_init_args = [
+        "--collection-path",
+        tdp_init[0],
+        "--database-dsn",
+        tdp_init[1],
+    ]
     runner = CliRunner()
-    result = runner.invoke(ops, [*tdp_init[:-2], "service_install"])
+    result = runner.invoke(ops, [*tdp_init_args, "service_install"])
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/plan/test_ops.py
+++ b/tdp/cli/commands/plan/test_ops.py
@@ -16,7 +16,7 @@ def test_tdp_plan_run(
         ops,
         [
             "--collection-path",
-            tdp_init.collection_path,
+            str(tdp_init.collection_path),
             "--database-dsn",
             tdp_init.db_dsn,
             "service_install",

--- a/tdp/cli/commands/plan/test_ops.py
+++ b/tdp/cli/commands/plan/test_ops.py
@@ -1,23 +1,15 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.init import init
 from tdp.cli.commands.plan.ops import ops
 
 
-def test_tdp_plan_run(collection_path: Path, db_dsn: str, vars: Path):
-    base_args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-    ]
+def test_tdp_plan_run(
+    tdp_init: list,
+):
     runner = CliRunner()
-    result = runner.invoke(init, [*base_args, "--vars", str(vars)])
-    assert result.exit_code == 0, result.output
-    result = runner.invoke(ops, [*base_args, "service_install"])
+    result = runner.invoke(ops, [*tdp_init[:-2], "service_install"])
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/plan/test_reconfigure.py
+++ b/tdp/cli/commands/plan/test_reconfigure.py
@@ -4,20 +4,21 @@
 
 from click.testing import CliRunner
 
+from tdp.cli.commands.conftest import tdp_init_args
 from tdp.cli.commands.plan.reconfigure import reconfigure
 
 
 def test_tdp_plan_reconfigure(
-    tdp_init: tuple,
+    tdp_init: tdp_init_args,
 ):
-    tdp_init_args = [
+    base_args = [
         "--collection-path",
-        tdp_init[0],
+        tdp_init.collection_path,
         "--database-dsn",
-        tdp_init[1],
+        tdp_init.db_dsn,
     ]
     runner = CliRunner()
-    result = runner.invoke(reconfigure, tdp_init_args)
+    result = runner.invoke(reconfigure, base_args)
     assert (
         result.exit_code == 1
     ), result.output  # No stale components, hence nothing to reconfigure.

--- a/tdp/cli/commands/plan/test_reconfigure.py
+++ b/tdp/cli/commands/plan/test_reconfigure.py
@@ -8,10 +8,16 @@ from tdp.cli.commands.plan.reconfigure import reconfigure
 
 
 def test_tdp_plan_reconfigure(
-    tdp_init: list,
+    tdp_init: tuple,
 ):
+    tdp_init_args = [
+        "--collection-path",
+        tdp_init[0],
+        "--database-dsn",
+        tdp_init[1],
+    ]
     runner = CliRunner()
-    result = runner.invoke(reconfigure, tdp_init[:-2])
+    result = runner.invoke(reconfigure, tdp_init_args)
     assert (
         result.exit_code == 1
     ), result.output  # No stale components, hence nothing to reconfigure.

--- a/tdp/cli/commands/plan/test_reconfigure.py
+++ b/tdp/cli/commands/plan/test_reconfigure.py
@@ -4,12 +4,12 @@
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.conftest import tdp_init_args
+from tdp.cli.commands.conftest import TDPInitArgs
 from tdp.cli.commands.plan.reconfigure import reconfigure
 
 
 def test_tdp_plan_reconfigure(
-    tdp_init: tdp_init_args,
+    tdp_init: TDPInitArgs,
 ):
     runner = CliRunner()
     result = runner.invoke(

--- a/tdp/cli/commands/plan/test_reconfigure.py
+++ b/tdp/cli/commands/plan/test_reconfigure.py
@@ -1,25 +1,17 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.init import init
 from tdp.cli.commands.plan.reconfigure import reconfigure
 
 
-def test_tdp_plan_reconfigure(collection_path: Path, db_dsn: str, vars: Path):
-    base_args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-    ]
+def test_tdp_plan_reconfigure(
+    tdp_init: list,
+):
     runner = CliRunner()
-    result = runner.invoke(init, [*base_args, "--vars", str(vars)])
-    assert result.exit_code == 0, result.output
-    result = runner.invoke(reconfigure, base_args)
+    result = runner.invoke(reconfigure, tdp_init[:-2])
     assert (
         result.exit_code == 1
     ), result.output  # No stale components, hence nothing to reconfigure.

--- a/tdp/cli/commands/plan/test_reconfigure.py
+++ b/tdp/cli/commands/plan/test_reconfigure.py
@@ -11,14 +11,16 @@ from tdp.cli.commands.plan.reconfigure import reconfigure
 def test_tdp_plan_reconfigure(
     tdp_init: tdp_init_args,
 ):
-    base_args = [
-        "--collection-path",
-        tdp_init.collection_path,
-        "--database-dsn",
-        tdp_init.db_dsn,
-    ]
     runner = CliRunner()
-    result = runner.invoke(reconfigure, base_args)
+    result = runner.invoke(
+        reconfigure,
+        [
+            "--collection-path",
+            tdp_init.collection_path,
+            "--database-dsn",
+            tdp_init.db_dsn,
+        ],
+    )
     assert (
         result.exit_code == 1
     ), result.output  # No stale components, hence nothing to reconfigure.

--- a/tdp/cli/commands/plan/test_reconfigure.py
+++ b/tdp/cli/commands/plan/test_reconfigure.py
@@ -16,7 +16,7 @@ def test_tdp_plan_reconfigure(
         reconfigure,
         [
             "--collection-path",
-            tdp_init.collection_path,
+            str(tdp_init.collection_path),
             "--database-dsn",
             tdp_init.db_dsn,
         ],

--- a/tdp/cli/commands/plan/test_resume.py
+++ b/tdp/cli/commands/plan/test_resume.py
@@ -4,22 +4,22 @@
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.conftest import tdp_init_args
+from tdp.cli.commands.conftest import TDPInitArgs
 from tdp.cli.commands.plan.dag import dag
 from tdp.cli.commands.plan.resume import resume
 
 
 def test_tdp_plan_resume_nothing_to_resume(
-    tdp_init: tdp_init_args,
+    tdp_init: TDPInitArgs,
 ):
-    base_args = [
+    common_args = [
         "--collection-path",
         tdp_init.collection_path,
         "--database-dsn",
         tdp_init.db_dsn,
     ]
     runner = CliRunner()
-    result = runner.invoke(dag, base_args)
+    result = runner.invoke(dag, common_args)
     assert result.exit_code == 0, result.output
-    result = runner.invoke(resume, base_args)
+    result = runner.invoke(resume, common_args)
     assert result.exit_code == 1, result.output  # No deployment to resume.

--- a/tdp/cli/commands/plan/test_resume.py
+++ b/tdp/cli/commands/plan/test_resume.py
@@ -4,21 +4,22 @@
 
 from click.testing import CliRunner
 
+from tdp.cli.commands.conftest import tdp_init_args
 from tdp.cli.commands.plan.dag import dag
 from tdp.cli.commands.plan.resume import resume
 
 
 def test_tdp_plan_resume_nothing_to_resume(
-    tdp_init: tuple,
+    tdp_init: tdp_init_args,
 ):
-    tdp_init_args = [
+    base_args = [
         "--collection-path",
-        tdp_init[0],
+        tdp_init.collection_path,
         "--database-dsn",
-        tdp_init[1],
+        tdp_init.db_dsn,
     ]
     runner = CliRunner()
-    result = runner.invoke(dag, tdp_init_args)
+    result = runner.invoke(dag, base_args)
     assert result.exit_code == 0, result.output
-    result = runner.invoke(resume, tdp_init_args)
+    result = runner.invoke(resume, base_args)
     assert result.exit_code == 1, result.output  # No deployment to resume.

--- a/tdp/cli/commands/plan/test_resume.py
+++ b/tdp/cli/commands/plan/test_resume.py
@@ -1,28 +1,18 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.init import init
 from tdp.cli.commands.plan.dag import dag
 from tdp.cli.commands.plan.resume import resume
 
 
 def test_tdp_plan_resume_nothing_to_resume(
-    collection_path: Path, db_dsn: str, vars: Path
+    tdp_init: list,
 ):
-    base_args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-    ]
     runner = CliRunner()
-    result = runner.invoke(init, [*base_args, "--vars", str(vars)])
+    result = runner.invoke(dag, tdp_init[:-2])
     assert result.exit_code == 0, result.output
-    result = runner.invoke(dag, base_args)
-    assert result.exit_code == 0, result.output
-    result = runner.invoke(resume, base_args)
+    result = runner.invoke(resume, tdp_init[:-2])
     assert result.exit_code == 1, result.output  # No deployment to resume.

--- a/tdp/cli/commands/plan/test_resume.py
+++ b/tdp/cli/commands/plan/test_resume.py
@@ -14,7 +14,7 @@ def test_tdp_plan_resume_nothing_to_resume(
 ):
     common_args = [
         "--collection-path",
-        tdp_init.collection_path,
+        str(tdp_init.collection_path),
         "--database-dsn",
         tdp_init.db_dsn,
     ]

--- a/tdp/cli/commands/plan/test_resume.py
+++ b/tdp/cli/commands/plan/test_resume.py
@@ -9,10 +9,16 @@ from tdp.cli.commands.plan.resume import resume
 
 
 def test_tdp_plan_resume_nothing_to_resume(
-    tdp_init: list,
+    tdp_init: tuple,
 ):
+    tdp_init_args = [
+        "--collection-path",
+        tdp_init[0],
+        "--database-dsn",
+        tdp_init[1],
+    ]
     runner = CliRunner()
-    result = runner.invoke(dag, tdp_init[:-2])
+    result = runner.invoke(dag, tdp_init_args)
     assert result.exit_code == 0, result.output
-    result = runner.invoke(resume, tdp_init[:-2])
+    result = runner.invoke(resume, tdp_init_args)
     assert result.exit_code == 1, result.output  # No deployment to resume.

--- a/tdp/cli/commands/status/test_edit.py
+++ b/tdp/cli/commands/status/test_edit.py
@@ -16,11 +16,11 @@ def test_tdp_status_edit(
         edit,
         [
             "--collection-path",
-            tdp_init.collection_path,
+            str(tdp_init.collection_path),
             "--database-dsn",
             tdp_init.db_dsn,
             "--vars",
-            tdp_init.vars,
+            str(tdp_init.vars),
             "service",
             "--host",
             "localhost",

--- a/tdp/cli/commands/status/test_edit.py
+++ b/tdp/cli/commands/status/test_edit.py
@@ -4,20 +4,21 @@
 
 from click.testing import CliRunner
 
+from tdp.cli.commands.conftest import tdp_init_args
 from tdp.cli.commands.status.edit import edit
 
 
 def test_tdp_status_edit(
-    tdp_init: tuple,
+    tdp_init: tdp_init_args,
 ):
-    tdp_init_args = [
+    base_args = [
         "--collection-path",
-        tdp_init[0],
+        tdp_init.collection_path,
         "--database-dsn",
-        tdp_init[1],
+        tdp_init.db_dsn,
         "--vars",
-        tdp_init[2],
+        tdp_init.vars,
     ]
     runner = CliRunner()
-    result = runner.invoke(edit, [*tdp_init_args, "service", "--host", "localhost"])
+    result = runner.invoke(edit, [*base_args, "service", "--host", "localhost"])
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_edit.py
+++ b/tdp/cli/commands/status/test_edit.py
@@ -8,8 +8,16 @@ from tdp.cli.commands.status.edit import edit
 
 
 def test_tdp_status_edit(
-    tdp_init: list,
+    tdp_init: tuple,
 ):
+    tdp_init_args = [
+        "--collection-path",
+        tdp_init[0],
+        "--database-dsn",
+        tdp_init[1],
+        "--vars",
+        tdp_init[2],
+    ]
     runner = CliRunner()
-    result = runner.invoke(edit, [*tdp_init, "service", "--host", "localhost"])
+    result = runner.invoke(edit, [*tdp_init_args, "service", "--host", "localhost"])
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_edit.py
+++ b/tdp/cli/commands/status/test_edit.py
@@ -1,25 +1,15 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.init import init
 from tdp.cli.commands.status.edit import edit
 
 
-def test_tdp_status_edit(collection_path: Path, db_dsn: str, vars: Path):
-    base_args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-        "--vars",
-        str(vars),
-    ]
+def test_tdp_status_edit(
+    tdp_init: list,
+):
     runner = CliRunner()
-    result = runner.invoke(init, base_args)
-    assert result.exit_code == 0, result.output
-    result = runner.invoke(edit, [*base_args, "service", "--host", "localhost"])
+    result = runner.invoke(edit, [*tdp_init, "service", "--host", "localhost"])
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_edit.py
+++ b/tdp/cli/commands/status/test_edit.py
@@ -4,25 +4,23 @@
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.conftest import tdp_init_args
+from tdp.cli.commands.conftest import TDPInitArgs
 from tdp.cli.commands.status.edit import edit
 
 
 def test_tdp_status_edit(
-    tdp_init: tdp_init_args,
+    tdp_init: TDPInitArgs,
 ):
     runner = CliRunner()
     result = runner.invoke(
         edit,
         [
-            *[
-                "--collection-path",
-                tdp_init.collection_path,
-                "--database-dsn",
-                tdp_init.db_dsn,
-                "--vars",
-                tdp_init.vars,
-            ],
+            "--collection-path",
+            tdp_init.collection_path,
+            "--database-dsn",
+            tdp_init.db_dsn,
+            "--vars",
+            tdp_init.vars,
             "service",
             "--host",
             "localhost",

--- a/tdp/cli/commands/status/test_edit.py
+++ b/tdp/cli/commands/status/test_edit.py
@@ -11,14 +11,21 @@ from tdp.cli.commands.status.edit import edit
 def test_tdp_status_edit(
     tdp_init: tdp_init_args,
 ):
-    base_args = [
-        "--collection-path",
-        tdp_init.collection_path,
-        "--database-dsn",
-        tdp_init.db_dsn,
-        "--vars",
-        tdp_init.vars,
-    ]
     runner = CliRunner()
-    result = runner.invoke(edit, [*base_args, "service", "--host", "localhost"])
+    result = runner.invoke(
+        edit,
+        [
+            *[
+                "--collection-path",
+                tdp_init.collection_path,
+                "--database-dsn",
+                tdp_init.db_dsn,
+                "--vars",
+                tdp_init.vars,
+            ],
+            "service",
+            "--host",
+            "localhost",
+        ],
+    )
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_generate_stales.py
+++ b/tdp/cli/commands/status/test_generate_stales.py
@@ -4,20 +4,21 @@
 
 from click.testing import CliRunner
 
+from tdp.cli.commands.conftest import tdp_init_args
 from tdp.cli.commands.status.generate_stales import generate_stales
 
 
 def test_tdp_status_edit(
-    tdp_init: tuple,
+    tdp_init: tdp_init_args,
 ):
-    tdp_init_args = [
+    base_args = [
         "--collection-path",
-        tdp_init[0],
+        tdp_init.collection_path,
         "--database-dsn",
-        tdp_init[1],
+        tdp_init.db_dsn,
         "--vars",
-        tdp_init[2],
+        tdp_init.vars,
     ]
     runner = CliRunner()
-    result = runner.invoke(generate_stales, tdp_init_args)
+    result = runner.invoke(generate_stales, base_args)
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_generate_stales.py
+++ b/tdp/cli/commands/status/test_generate_stales.py
@@ -8,8 +8,16 @@ from tdp.cli.commands.status.generate_stales import generate_stales
 
 
 def test_tdp_status_edit(
-    tdp_init: list,
+    tdp_init: tuple,
 ):
+    tdp_init_args = [
+        "--collection-path",
+        tdp_init[0],
+        "--database-dsn",
+        tdp_init[1],
+        "--vars",
+        tdp_init[2],
+    ]
     runner = CliRunner()
-    result = runner.invoke(generate_stales, tdp_init)
+    result = runner.invoke(generate_stales, tdp_init_args)
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_generate_stales.py
+++ b/tdp/cli/commands/status/test_generate_stales.py
@@ -16,11 +16,11 @@ def test_tdp_status_edit(
         generate_stales,
         [
             "--collection-path",
-            tdp_init.collection_path,
+            str(tdp_init.collection_path),
             "--database-dsn",
             tdp_init.db_dsn,
             "--vars",
-            tdp_init.vars,
+            str(tdp_init.vars),
         ],
     )
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_generate_stales.py
+++ b/tdp/cli/commands/status/test_generate_stales.py
@@ -4,12 +4,12 @@
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.conftest import tdp_init_args
+from tdp.cli.commands.conftest import TDPInitArgs
 from tdp.cli.commands.status.generate_stales import generate_stales
 
 
 def test_tdp_status_edit(
-    tdp_init: tdp_init_args,
+    tdp_init: TDPInitArgs,
 ):
     runner = CliRunner()
     result = runner.invoke(

--- a/tdp/cli/commands/status/test_generate_stales.py
+++ b/tdp/cli/commands/status/test_generate_stales.py
@@ -1,25 +1,15 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.init import init
 from tdp.cli.commands.status.generate_stales import generate_stales
 
 
-def test_tdp_status_edit(collection_path: Path, db_dsn: str, vars: Path):
-    base_args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-        "--vars",
-        str(vars),
-    ]
+def test_tdp_status_edit(
+    tdp_init: list,
+):
     runner = CliRunner()
-    result = runner.invoke(init, base_args)
-    assert result.exit_code == 0, result.output
-    result = runner.invoke(generate_stales, base_args)
+    result = runner.invoke(generate_stales, tdp_init)
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_generate_stales.py
+++ b/tdp/cli/commands/status/test_generate_stales.py
@@ -11,14 +11,16 @@ from tdp.cli.commands.status.generate_stales import generate_stales
 def test_tdp_status_edit(
     tdp_init: tdp_init_args,
 ):
-    base_args = [
-        "--collection-path",
-        tdp_init.collection_path,
-        "--database-dsn",
-        tdp_init.db_dsn,
-        "--vars",
-        tdp_init.vars,
-    ]
     runner = CliRunner()
-    result = runner.invoke(generate_stales, base_args)
+    result = runner.invoke(
+        generate_stales,
+        [
+            "--collection-path",
+            tdp_init.collection_path,
+            "--database-dsn",
+            tdp_init.db_dsn,
+            "--vars",
+            tdp_init.vars,
+        ],
+    )
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_show.py
+++ b/tdp/cli/commands/status/test_show.py
@@ -11,14 +11,16 @@ from tdp.cli.commands.status.show import show
 def test_tdp_status_edit(
     tdp_init: tdp_init_args,
 ):
-    base_args = [
-        "--collection-path",
-        tdp_init.collection_path,
-        "--database-dsn",
-        tdp_init.db_dsn,
-        "--vars",
-        tdp_init.vars,
-    ]
     runner = CliRunner()
-    result = runner.invoke(show, base_args)
+    result = runner.invoke(
+        show,
+        [
+            "--collection-path",
+            tdp_init.collection_path,
+            "--database-dsn",
+            tdp_init.db_dsn,
+            "--vars",
+            tdp_init.vars,
+        ],
+    )
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_show.py
+++ b/tdp/cli/commands/status/test_show.py
@@ -16,11 +16,11 @@ def test_tdp_status_edit(
         show,
         [
             "--collection-path",
-            tdp_init.collection_path,
+            str(tdp_init.collection_path),
             "--database-dsn",
             tdp_init.db_dsn,
             "--vars",
-            tdp_init.vars,
+            str(tdp_init.vars),
         ],
     )
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_show.py
+++ b/tdp/cli/commands/status/test_show.py
@@ -1,25 +1,15 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.init import init
 from tdp.cli.commands.status.show import show
 
 
-def test_tdp_status_edit(collection_path: Path, db_dsn: str, vars: Path):
-    base_args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-        "--vars",
-        str(vars),
-    ]
+def test_tdp_status_edit(
+    tdp_init: list,
+):
     runner = CliRunner()
-    result = runner.invoke(init, base_args)
-    assert result.exit_code == 0, result.output
-    result = runner.invoke(show, base_args)
+    result = runner.invoke(show, tdp_init)
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_show.py
+++ b/tdp/cli/commands/status/test_show.py
@@ -4,20 +4,21 @@
 
 from click.testing import CliRunner
 
+from tdp.cli.commands.conftest import tdp_init_args
 from tdp.cli.commands.status.show import show
 
 
 def test_tdp_status_edit(
-    tdp_init: tuple,
+    tdp_init: tdp_init_args,
 ):
-    tdp_init_args = [
+    base_args = [
         "--collection-path",
-        tdp_init[0],
+        tdp_init.collection_path,
         "--database-dsn",
-        tdp_init[1],
+        tdp_init.db_dsn,
         "--vars",
-        tdp_init[2],
+        tdp_init.vars,
     ]
     runner = CliRunner()
-    result = runner.invoke(show, tdp_init_args)
+    result = runner.invoke(show, base_args)
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/status/test_show.py
+++ b/tdp/cli/commands/status/test_show.py
@@ -4,12 +4,12 @@
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.conftest import tdp_init_args
+from tdp.cli.commands.conftest import TDPInitArgs
 from tdp.cli.commands.status.show import show
 
 
 def test_tdp_status_edit(
-    tdp_init: tdp_init_args,
+    tdp_init: TDPInitArgs,
 ):
     runner = CliRunner()
     result = runner.invoke(

--- a/tdp/cli/commands/status/test_show.py
+++ b/tdp/cli/commands/status/test_show.py
@@ -8,8 +8,16 @@ from tdp.cli.commands.status.show import show
 
 
 def test_tdp_status_edit(
-    tdp_init: list,
+    tdp_init: tuple,
 ):
+    tdp_init_args = [
+        "--collection-path",
+        tdp_init[0],
+        "--database-dsn",
+        tdp_init[1],
+        "--vars",
+        tdp_init[2],
+    ]
     runner = CliRunner()
-    result = runner.invoke(show, tdp_init)
+    result = runner.invoke(show, tdp_init_args)
     assert result.exit_code == 0, result.output

--- a/tdp/cli/commands/test_deploy.py
+++ b/tdp/cli/commands/test_deploy.py
@@ -15,15 +15,6 @@ def test_tdp_deploy_mock(
     tdp_init: tdp_init_args,
     tmp_path: Path,
 ):
-
-    base_args = [
-        "--collection-path",
-        tdp_init.collection_path,
-        "--database-dsn",
-        tdp_init.db_dsn,
-        "--vars",
-        tdp_init.vars,
-    ]
     runner = CliRunner()
     result = runner.invoke(
         dag,
@@ -38,7 +29,14 @@ def test_tdp_deploy_mock(
     result = runner.invoke(
         deploy,
         [
-            *base_args,
+            *[
+                "--collection-path",
+                tdp_init.collection_path,
+                "--database-dsn",
+                tdp_init.db_dsn,
+                "--vars",
+                tdp_init.vars,
+            ],
             "--run-directory",
             str(tmp_path),
             "--mock-deploy",

--- a/tdp/cli/commands/test_deploy.py
+++ b/tdp/cli/commands/test_deploy.py
@@ -20,7 +20,7 @@ def test_tdp_deploy_mock(
         dag,
         [
             "--collection-path",
-            tdp_init.collection_path,
+            str(tdp_init.collection_path),
             "--database-dsn",
             tdp_init.db_dsn,
         ],
@@ -30,11 +30,11 @@ def test_tdp_deploy_mock(
         deploy,
         [
             "--collection-path",
-            tdp_init.collection_path,
+            str(tdp_init.collection_path),
             "--database-dsn",
             tdp_init.db_dsn,
             "--vars",
-            tdp_init.vars,
+            str(tdp_init.vars),
             "--run-directory",
             str(tmp_path),
             "--mock-deploy",

--- a/tdp/cli/commands/test_deploy.py
+++ b/tdp/cli/commands/test_deploy.py
@@ -6,13 +6,13 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from tdp.cli.commands.conftest import tdp_init_args
+from tdp.cli.commands.conftest import TDPInitArgs
 from tdp.cli.commands.deploy import deploy
 from tdp.cli.commands.plan.dag import dag
 
 
 def test_tdp_deploy_mock(
-    tdp_init: tdp_init_args,
+    tdp_init: TDPInitArgs,
     tmp_path: Path,
 ):
     runner = CliRunner()
@@ -29,14 +29,12 @@ def test_tdp_deploy_mock(
     result = runner.invoke(
         deploy,
         [
-            *[
-                "--collection-path",
-                tdp_init.collection_path,
-                "--database-dsn",
-                tdp_init.db_dsn,
-                "--vars",
-                tdp_init.vars,
-            ],
+            "--collection-path",
+            tdp_init.collection_path,
+            "--database-dsn",
+            tdp_init.db_dsn,
+            "--vars",
+            tdp_init.vars,
             "--run-directory",
             str(tmp_path),
             "--mock-deploy",

--- a/tdp/cli/commands/test_deploy.py
+++ b/tdp/cli/commands/test_deploy.py
@@ -11,16 +11,27 @@ from tdp.cli.commands.plan.dag import dag
 
 
 def test_tdp_deploy_mock(
-    tdp_init: list,
+    tdp_init: tuple,
     tmp_path: Path,
 ):
+
+    tdp_init_args = [
+        "--collection-path",
+        tdp_init[0],
+        "--database-dsn",
+        tdp_init[1],
+        "--vars",
+        tdp_init[2],
+    ]
     runner = CliRunner()
-    result = runner.invoke(dag, tdp_init[:-2])
+    result = runner.invoke(
+        dag, ["--collection-path", tdp_init[0], "--database-dsn", tdp_init[1]]
+    )
     assert result.exit_code == 0, result.output
     result = runner.invoke(
         deploy,
         [
-            *tdp_init,
+            *tdp_init_args,
             "--run-directory",
             str(tmp_path),
             "--mock-deploy",

--- a/tdp/cli/commands/test_deploy.py
+++ b/tdp/cli/commands/test_deploy.py
@@ -1,35 +1,26 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
+
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from tdp.cli.commands.deploy import deploy
-from tdp.cli.commands.init import init
 from tdp.cli.commands.plan.dag import dag
 
 
 def test_tdp_deploy_mock(
-    collection_path: Path, db_dsn: str, vars: Path, tmp_path: Path
+    tdp_init: list,
+    tmp_path: Path,
 ):
-    base_args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-    ]
     runner = CliRunner()
-    result = runner.invoke(init, [*base_args, "--vars", str(vars)])
-    assert result.exit_code == 0, result.output
-    result = runner.invoke(dag, base_args)
+    result = runner.invoke(dag, tdp_init[:-2])
     assert result.exit_code == 0, result.output
     result = runner.invoke(
         deploy,
         [
-            *base_args,
-            "--vars",
-            str(vars),
+            *tdp_init,
             "--run-directory",
             str(tmp_path),
             "--mock-deploy",

--- a/tdp/cli/commands/test_deploy.py
+++ b/tdp/cli/commands/test_deploy.py
@@ -6,32 +6,39 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+from tdp.cli.commands.conftest import tdp_init_args
 from tdp.cli.commands.deploy import deploy
 from tdp.cli.commands.plan.dag import dag
 
 
 def test_tdp_deploy_mock(
-    tdp_init: tuple,
+    tdp_init: tdp_init_args,
     tmp_path: Path,
 ):
 
-    tdp_init_args = [
+    base_args = [
         "--collection-path",
-        tdp_init[0],
+        tdp_init.collection_path,
         "--database-dsn",
-        tdp_init[1],
+        tdp_init.db_dsn,
         "--vars",
-        tdp_init[2],
+        tdp_init.vars,
     ]
     runner = CliRunner()
     result = runner.invoke(
-        dag, ["--collection-path", tdp_init[0], "--database-dsn", tdp_init[1]]
+        dag,
+        [
+            "--collection-path",
+            tdp_init.collection_path,
+            "--database-dsn",
+            tdp_init.db_dsn,
+        ],
     )
     assert result.exit_code == 0, result.output
     result = runner.invoke(
         deploy,
         [
-            *tdp_init_args,
+            *base_args,
             "--run-directory",
             str(tmp_path),
             "--mock-deploy",

--- a/tdp/cli/commands/test_init.py
+++ b/tdp/cli/commands/test_init.py
@@ -9,20 +9,6 @@ from click.testing import CliRunner
 from tdp.cli.commands.init import init
 
 
-def test_tdp_init(collection_path: Path, db_dsn: str, vars: Path):
-    args = [
-        "--collection-path",
-        collection_path,
-        "--database-dsn",
-        db_dsn,
-        "--vars",
-        vars,
-    ]
-    runner = CliRunner()
-    result = runner.invoke(init, args)
-    assert result.exit_code == 0, result.output
-
-
 def test_tdp_init_db_is_created(collection_path: Path, vars: Path, tmp_path: Path):
     db_path = tmp_path / "sqlite.db"
     args = [

--- a/tdp/cli/commands/test_init.py
+++ b/tdp/cli/commands/test_init.py
@@ -13,11 +13,11 @@ def test_tdp_init_db_is_created(collection_path: Path, vars: Path, tmp_path: Pat
     db_path = tmp_path / "sqlite.db"
     args = [
         "--collection-path",
-        collection_path,
+        str(collection_path),
         "--database-dsn",
         "sqlite:///" + str(db_path),
         "--vars",
-        vars,
+        str(vars),
     ]
     runner = CliRunner()
     result = runner.invoke(init, args)

--- a/tdp/conftest.py
+++ b/tdp/conftest.py
@@ -68,7 +68,8 @@ def db_engine(
     if request.param:
         init_database(engine)
     yield engine
-    BaseModel.metadata.drop_all(engine)
+    if request.param:
+        BaseModel.metadata.drop_all(engine)
     engine.dispose()
 
 

--- a/tdp/conftest.py
+++ b/tdp/conftest.py
@@ -57,10 +57,6 @@ def db_dsn(
     if database_dsn == "sqlite":
         database_dsn = f"sqlite:///{tmp_path / 'test.db'}"
     yield database_dsn
-    # Drop the database content
-    engine = create_engine(database_dsn)
-    BaseModel.metadata.drop_all(engine)
-    engine.dispose()
 
 
 @pytest.fixture()
@@ -72,6 +68,7 @@ def db_engine(
     if request.param:
         init_database(engine)
     yield engine
+    BaseModel.metadata.drop_all(engine)
     engine.dispose()
 
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

This PR is necessary for the PR Dev/alembic migration #563. When we integrate Alembic in the `init` command, it creates a new engine and synchronization problems occur between the engines when launching the unit tests although it works manually when we perform one command after another. Therefore, the `init` command has been left out of all unit tests and replaced with hard coded initialization except the test which specifically tests the `init` command of course.

The engine is created and closed also in the tests since we import the functions with the `click` decorators which take as input a `database-dsn` and not an engine.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
