### PR TITLE
fix: deprecated way to query in sqlalchemy

### DIFF
--- a/tdp/dao.py
+++ b/tdp/dao.py
@@ -102,4 +102,4 @@ class Dao:
             id: Deployment ID.
         """
         self._check_session()
-        return self.session.query(DeploymentModel).get(id)
+        return self.session.get(DeploymentModel, id)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

`return self.session.query(DeploymentModel).get(id)` is deprecated in sqlalchemy 2.0 and will not be supported in next version.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
