### PR TITLE
refactor: database_dsn_option parameter to return either engine or dsn

### DIFF
--- a/tdp/cli/params/database_dsn_option.py
+++ b/tdp/cli/params/database_dsn_option.py
@@ -1,6 +1,9 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
+from typing import Optional
+
 import click
 from click.decorators import FC
 from sqlalchemy import Engine, create_engine
@@ -20,22 +23,32 @@ def _engine_from_dsn(ctx: click.Context, param: click.Parameter, value: str) -> 
     return create_engine(value, future=True)
 
 
-def database_dsn_option(func: FC) -> FC:
+def database_dsn_option(
+    func: Optional[FC] = None, create_engine: bool = True
+) -> Callable[[FC], FC]:
     """Click option that adds a database_dsn option to the command.
 
-    The option is required and the value is a string. It returns a sqlalchemy engine.
+    It returns a sqlalchemy engine if create_engine is True, otherwise it returns the database_dsn.
     """
-    return click.option(
-        "db_engine",
-        "--database-dsn",
-        envvar="TDP_DATABASE_DSN",
-        required=True,
-        type=str,
-        callback=_engine_from_dsn,
-        help=(
-            "Database Data Source Name, in sqlalchemy driver form "
-            "example: sqlite:////data/tdp.db or sqlite+pysqlite:////data/tdp.db. "
-            "You might need to install the relevant driver to your installation (such "
-            "as psycopg2 for postgresql)."
-        ),
-    )(func)
+
+    def decorator(fn: FC) -> FC:
+        return click.option(
+            "db_engine",
+            "--database-dsn",
+            envvar="TDP_DATABASE_DSN",
+            required=True,
+            type=str,
+            callback=_engine_from_dsn if create_engine else None,
+            help=(
+                "Database Data Source Name, in sqlalchemy driver form "
+                "example: sqlite:////data/tdp.db or sqlite+pysqlite:////data/tdp.db. "
+                "You might need to install the relevant driver to your installation (such "
+                "as psycopg2 for postgresql)."
+            ),
+        )(fn)
+
+    # Checks if the decorator was used without parentheses.
+    if func is None:
+        return decorator
+    else:
+        return decorator(func)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

The function `database_dsn_option` returns an engine while we also need the database-dsn. This PR enables the the function to return both.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
