### PR TITLE
fix: change value order for is_active column when using query _create_last_value_statement

### DIFF
--- a/tdp/dao.py
+++ b/tdp/dao.py
@@ -24,7 +24,11 @@ def _create_last_value_statement(column, non_null=False):
     """
     order_by = SCHStatusLogModel.event_time.desc()
     if non_null:
-        order_by = case((column == None, 0), else_=1).desc(), order_by
+        order_by = (
+            case((column == None, 0), else_=1).desc()
+            if column is not SCHStatusLogModel.is_active
+            else case((column == None, 1), else_=0).desc()
+        ), order_by
     return func.first_value(column).over(
         partition_by=(
             SCHStatusLogModel.service,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

The function `_create_get_sch_latest_status_statement` in `tdp/dao.py` used by the query from the command `tdp status show` takes the `latest_is_active`, and until now `None` meant True for `is_active`. However, in the order of the query False precedes None so the query will first return a False before a None which is not the expected behavior. Therefore, the order has been changed for the is_active column.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
