### PR TITLE
fix: to_restart and to_config in get_hosted_entity_statuses

### DIFF
--- a/tdp/cli/commands/plan/reconfigure.py
+++ b/tdp/cli/commands/plan/reconfigure.py
@@ -39,7 +39,7 @@ def reconfigure(
         deployment = DeploymentModel.from_stale_hosted_entities(
             collections=collections,
             stale_hosted_entity_statuses=dao.get_hosted_entity_statuses(
-                filter_stale=True
+                filter_stale=True, filter_active=True
             ),
             rolling_interval=rolling_interval,
         )


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

The `to_restart` and `to_config` indicators must be true only if component is active, otherwise if it belongs to a node that has been decommissioned there is no point to restart or reconfigure it and it will fail anyways since the host is not there anymore. Therefore an additional condition has been put for these indicators to be true.

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
