### PR TITLE
fix: deploy exception playbooks always on all hosts

### DIFF
--- a/tdp/core/deployment/executor.py
+++ b/tdp/core/deployment/executor.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 from tdp.core.models.enums import OperationStateEnum
+from tdp.exception_playbooks import exception_playbooks
 from tdp.utils import resolve_executable
 
 logger = logging.getLogger(__name__)
@@ -95,7 +96,15 @@ class Executor:
         command = [self.ansible_path]
         command += [str(playbook)]
         if host is not None:
-            command += ["--limit", host]
+            command += [
+                "--limit",
+                (
+                    host
+                    if "/".join(str(playbook).rsplit("/", 3)[-3:])
+                    not in exception_playbooks
+                    else "all"
+                ),
+            ]
         for extra_var in extra_vars or []:
             command += ["--extra-vars", extra_var]
         # Execute command

--- a/tdp/exception_playbooks.py
+++ b/tdp/exception_playbooks.py
@@ -1,0 +1,10 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+# Exception playbooks are playbooks which have to be deployed on all hosts and never on one specific one.
+exception_playbooks = [
+    "tdp/playbooks/hbase_kerberos_install.yml",
+    "tdp/playbooks/hdfs_kerberos_install.yml",
+    "tdp/playbooks/yarn_kerberos_install.yml",
+    "tdp/playbooks/hadoop_client_config.yml",
+]


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

This is one approach to solve the issues of playbooks which always have to be deployed on all hosts even if only a specific one is set in the command. It is the case for the following playbooks in the tdp collection:
- tdp/playbooks/hbase_kerberos_install.yml
- tdp/playbooks/hdfs_kerberos_install.yml
- tdp/playbooks/yarn_kerberos_install.yml
- tdp/playbooks/hadoop_client_config.yml



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
