### PR TITLE
Import `merge_hash` from ansible directly

### DIFF
--- a/tdp/cli/commands/default_diff.py
+++ b/tdp/cli/commands/default_diff.py
@@ -10,10 +10,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import click
+from ansible.utils.vars import merge_hash
 
 from tdp.cli.params import collections_option, vars_option
 from tdp.core.constants import DEFAULT_VARS_DIRECTORY_NAME
-from tdp.core.variables import ClusterVariables, Variables, merge_hash
+from tdp.core.variables import ClusterVariables, Variables
 
 if TYPE_CHECKING:
     from tdp.core.collections import Collections

--- a/tdp/core/variables/__init__.py
+++ b/tdp/core/variables/__init__.py
@@ -5,4 +5,4 @@ from tdp.core.variables.cluster_variables import ClusterVariables
 from tdp.core.variables.service_variables import (
     ServiceVariables,
 )
-from tdp.core.variables.variables import Variables, VariablesDict, merge_hash
+from tdp.core.variables.variables import Variables, VariablesDict


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

For now `merge_hash` was imported / re-exported from `variables`  to be used by `default_diff`.

This PR import `merge_hash` from ansible  in `default_diff` directly.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
