### PR TITLE
Remove `CatchGroup` class

### DIFF
--- a/tdp/cli/__main__.py
+++ b/tdp/cli/__main__.py
@@ -24,17 +24,6 @@ from tdp.cli.logger import setup_logging
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
-class CatchGroup(click.Group):
-    """Catch exceptions and print them to stderr."""
-
-    def __call__(self, *args, **kwargs):
-        try:
-            return self.main(*args, **kwargs)
-
-        except Exception as e:
-            click.echo(f"Error: {e}", err=True)
-
-
 def load_env(ctx: click.Context, param: click.Parameter, value: Path) -> Optional[Path]:
     """Click callback to load the environment file."""
     if value.exists():
@@ -44,7 +33,7 @@ def load_env(ctx: click.Context, param: click.Parameter, value: Path) -> Optiona
         logging.warning(f"Environment file {value} does not exist.")
 
 
-@click.group("tdp", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
+@click.group("tdp", context_settings=CONTEXT_SETTINGS)
 @click.option(
     "--env",
     default=".env",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

The `CatchGroup` class is currently intercepting all exceptions, removing their stack trace. However, it shouldn't intercept errors coming from the core lib. Each command should properly catch its potential errors and eventually manage it through `[ClickException](https://click.palletsprojects.com/en/7.x/api/#click.ClickException)`.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
