### PR TITLE
fix: seperated _update_cluster_fn from _process_operation_fn to displ…

### DIFF
--- a/tdp/cli/commands/deploy.py
+++ b/tdp/cli/commands/deploy.py
@@ -98,11 +98,12 @@ def deploy(
         dao.session.commit()  # Update operation status to RUNNING
         for operation_rec, process_operation_fn in deployment_iterator:
             dao.session.commit()  # Update deployment and current operation status to RUNNING and next operations to PENDING
-            if process_operation_fn and (cluster_status_logs := process_operation_fn()):
+            if process_operation_fn:
                 click.echo(
                     f"Operation {operation_rec.operation} is {operation_rec.state} {'for hosts: ' + operation_rec.host if operation_rec.host is not None else ''}"
                 )
-                dao.session.add_all(cluster_status_logs)
+                if cluster_status_logs := process_operation_fn():
+                    dao.session.add_all(cluster_status_logs)
             dao.session.commit()  # Update operation status to SUCCESS, FAILURE or HELD
 
         if deployment_iterator.deployment.state != DeploymentStateEnum.SUCCESS:


### PR DESCRIPTION
fix: seperated _update_cluster_fn from _process_operation_fn to display deployment operations

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Before this PR the `tdp deploy` or `tdp deploy --mock-deploy` does not display the `-install` operations although they are executed and written in the database since they do not provide cluster_status_logs directly. Therefore in order to show these commands too, in the iterator the _process_operation_fn must be separated in two. one function which executes the operation and a second one which updates the status_logs.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
