### PR TITLE
fix: get rid of red error marker in get_components_from_service

### DIFF
--- a/tdp/core/dag.py
+++ b/tdp/core/dag.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Optional, TypeVar
 import networkx as nx
 
 from tdp.core.constants import DEFAULT_SERVICE_PRIORITY, SERVICE_PRIORITY
+from tdp.core.entities.operation import Operations
 from tdp.core.operation import Operation
 
 if TYPE_CHECKING:
@@ -50,7 +51,7 @@ class Dag:
         self._graph = self._generate_graph(self.operations)
 
     @property
-    def operations(self) -> dict[str, Operation]:
+    def operations(self) -> Operations:
         """DAG operations dictionary."""
         return self._operations
 
@@ -239,7 +240,7 @@ class Dag:
         )
 
     # TODO: can take a list of operations instead of a dict
-    def _generate_graph(self, nodes: dict[str, Operation]) -> nx.DiGraph:
+    def _generate_graph(self, nodes: Operations) -> nx.DiGraph:
         DG = nx.DiGraph()
         for operation_name, operation in nodes.items():
             DG.add_node(operation_name)
@@ -258,7 +259,7 @@ class Dag:
 
 # TODO: call this method inside of Collections._init_operations instead of the Dag constructor
 # TODO: remove Collections dependency
-def validate_dag_nodes(nodes: dict[str, Operation], collections: Collections) -> None:
+def validate_dag_nodes(nodes: Operations, collections: Collections) -> None:
     r"""Validation rules :
     - \*_start operations can only be required from within its own service
     - \*_install operations should only depend on other \*_install operations


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->
- Get rid of red error marker in get_components_from_service in Collections class.
- Get rid of red error marking in Dag class.


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
