### PR TITLE
Remove noop playbook check

### DIFF
--- a/tdp/core/dag.py
+++ b/tdp/core/dag.py
@@ -25,7 +25,6 @@ from tdp.core.entities.operation import (
     DagOperation,
     ForgedDagOperation,
     OperationName,
-    OperationNoop,
     PlaybookOperation,
 )
 
@@ -277,7 +276,6 @@ def validate_dag_nodes(
     - \*_start operations can only be required from within its own service
     - \*_install operations should only depend on other \*_install operations
     - Each service (HDFS, HBase, Hive, etc) should have \*_install, \*_config, \*_init and \*_start operations even if they are "empty" (tagged with noop)
-    - Operations tagged with the noop flag should not have a playbook defined in the collection
     - Each service action (config, start, init) except the first (install) must have an explicit dependency with the previous service operation within the same service
     """
     # key: service_name
@@ -350,18 +348,6 @@ def validate_dag_nodes(
                         f"Operation '{operation_name}' is a service action and has to depend on "
                         f"'{operation.name.service}_{previous_action}'"
                     )
-
-        # Operations tagged with the noop flag should not have a playbook defined in the collection
-
-        #! This case can't happen because no operation inherits both PlaybookOperation and NoOp
-        if str(operation_name) in collections.playbooks:
-            if isinstance(operation, OperationNoop):
-                c_warning(
-                    f"Operation '{operation_name}' is noop and the playbook should not exist"
-                )
-        else:
-            if not isinstance(operation, OperationNoop):
-                c_warning(f"Operation '{operation_name}' should have a playbook")
 
     # Each service (HDFS, HBase, Hive, etc) should have *_install, *_config, *_init and *_start actions
     # even if they are "empty" (tagged with noop)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

This check become useless. We are currently creating the list of operations from the dag and eventually assign them a playbook if define. Dag operations with no associated playbook are then treated as "noop". Hence, we are not using the `noop` property anymore.

Furthermore, this check doesn't cover the case where a noop is defined in `collection1` and then is completed with a playbook defined in `collection2`.

I suggest to also remove entirely the `noop` property from the dag files (in the collections) are it is not used anymore.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
