### PR TITLE
Introduce new operation entities

### DIFF
--- a/scripts/playbooks.py
+++ b/scripts/playbooks.py
@@ -53,7 +53,7 @@ def playbooks(services, output_dir, for_collection, collections):
     for operation in dag.get_all_operations():
         dag_services.add_node(operation.name.service)
         for dependency in operation.depends_on:
-            dependency_operation = OperationName.from_name(dependency)
+            dependency_operation = OperationName.from_str(dependency)
             if dependency_operation.service != operation.name.service:
                 dag_services.add_edge(
                     dependency_operation.service, operation.name.service

--- a/tdp/core/cluster_status.py
+++ b/tdp/core/cluster_status.py
@@ -18,6 +18,7 @@ from tdp.core.entities.hosted_entity import (
     create_hosted_entity,
 )
 from tdp.core.entities.hosted_entity_status import HostedEntityStatus
+from tdp.core.entities.operation import PlaybookOperation
 from tdp.core.models.sch_status_log_model import (
     SCHStatusLogModel,
     SCHStatusLogSourceEnum,
@@ -133,7 +134,11 @@ class ClusterStatus(MutableMapping[HostedEntity, HostedEntityStatus]):
                 continue
 
             # Create a log for each host where the entity is deployed
-            for host in operation.host_names:
+            for host in (
+                operation.playbook.hosts
+                if isinstance(operation, PlaybookOperation)
+                else []
+            ):
                 log = logs.setdefault(
                     create_hosted_entity(
                         create_entity_name(

--- a/tdp/core/collections/collection_reader.py
+++ b/tdp/core/collections/collection_reader.py
@@ -19,7 +19,7 @@ from tdp.core.constants import (
     SCHEMA_VARS_DIRECTORY_NAME,
     YML_EXTENSION,
 )
-from tdp.core.entities.operation import DagOperation, Playbook
+from tdp.core.entities.operation import Playbook
 from tdp.core.inventory_reader import InventoryReader
 from tdp.core.types import PathLike
 from tdp.core.variables.schema import ServiceCollectionSchema
@@ -49,6 +49,32 @@ class PathIsNotADirectoryError(Exception):
 
 class MissingMandatoryDirectoryError(Exception):
     pass
+
+
+class TDPLibDagNodeModel(BaseModel):
+    """Model for a DAG node read from a DAG file.
+
+    Meant to be used in a DagNodeBuilder.
+
+    Args:
+        name: Name of the operation.
+        depends_on: List of operations that must be executed before this one.
+        noop: Whether the operation is a noop.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    depends_on: frozenset[str] = frozenset()
+    noop: Optional[bool] = False
+
+
+class TDPLibDagModel(BaseModel):
+    """Model for a TDP DAG defined in a tdp_lib_dag file."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    operations: list[TDPLibDagNodeModel]
 
 
 class CollectionReader:
@@ -122,23 +148,8 @@ class CollectionReader:
         """Path to the variables schema directory."""
         return self._path / SCHEMA_VARS_DIRECTORY_NAME
 
-    def read_dag_nodes(self) -> Generator[DagOperation, None, None]:
+    def read_dag_nodes(self) -> Generator[TDPLibDagNodeModel, None, None]:
         """Read the DAG nodes stored in the dag_directory."""
-
-        class TDPLibDagNodeModel(BaseModel):
-            """Model for a TDP operation defined in a tdp_lib_dag file."""
-
-            model_config = ConfigDict(extra="ignore")
-
-            name: str
-            depends_on: frozenset[str] = frozenset()
-
-        class TDPLibDagModel(BaseModel):
-            """Model for a TDP DAG defined in a tdp_lib_dag file."""
-
-            model_config = ConfigDict(extra="ignore")
-
-            operations: list[TDPLibDagNodeModel]
 
         for dag_file in (self.dag_directory).glob("*" + YML_EXTENSION):
             with dag_file.open("r") as operations_file:
@@ -147,9 +158,7 @@ class CollectionReader:
             try:
                 tdp_lib_dag = TDPLibDagModel(operations=file_content)
                 for operation in tdp_lib_dag.operations:
-                    yield DagOperation.from_name(
-                        name=operation.name, depends_on=operation.depends_on
-                    )
+                    yield operation
             except ValidationError as e:
                 logger.error(f"Error while parsing tdp_lib_dag file {dag_file}: {e}")
                 raise
@@ -201,7 +210,7 @@ class CollectionReader:
 
 def read_hosts_from_playbook(
     playbook_path: Path, inventory_reader: Optional[InventoryReader]
-) -> set[str]:
+) -> frozenset[str]:
     """Read the hosts from a playbook.
 
     Args:

--- a/tdp/core/dag_dot.py
+++ b/tdp/core/dag_dot.py
@@ -54,7 +54,7 @@ def to_pydot(
         for dot_node in dot_nodes:
             # Dot node name can be quoted, remove it
             operation_name = dot_node.get_name().strip('"')
-            operation_name = OperationName.from_name(operation_name)
+            operation_name = OperationName.from_str(operation_name)
             subgraphs.setdefault(
                 operation_name.service,
                 pydot.Cluster(

--- a/tdp/core/deployment/deployment_runner.py
+++ b/tdp/core/deployment/deployment_runner.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from tdp.core.deployment.deployment_iterator import DeploymentIterator
+from tdp.core.entities.operation import PlaybookOperation
 from tdp.core.models.enums import DeploymentStateEnum, OperationStateEnum
 from tdp.core.variables import ClusterVariables
 
@@ -54,7 +55,10 @@ class DeploymentRunner:
         operation = self._collections.operations[operation_rec.operation]
 
         # Check if the operation is available for the given host
-        if operation_rec.host and operation_rec.host not in operation.host_names:
+        if operation_rec.host and (
+            not isinstance(operation, PlaybookOperation)
+            or operation_rec.host not in operation.playbook.hosts
+        ):
             logs = (
                 f"Operation '{operation_rec.operation}' not available for host "
                 + f"'{operation_rec.host}'"

--- a/tdp/core/inventory_reader.py
+++ b/tdp/core/inventory_reader.py
@@ -56,7 +56,7 @@ class InventoryReader:
         # so we convert them to "str"
         return [str(host) for host in self.inventory.get_hosts(*args, **kwargs)]
 
-    def get_hosts_from_playbook(self, fd: TextIO) -> set[str]:
+    def get_hosts_from_playbook(self, fd: TextIO) -> frozenset[str]:
         """Takes a playbook content, read all plays inside and return a set
         of matching host like "ansible-playbook --list-hosts playbook.yml".
 
@@ -81,4 +81,4 @@ class InventoryReader:
                 )
             hosts.update(self.get_hosts(play["hosts"]))
 
-        return hosts
+        return frozenset(hosts)

--- a/test_dag_order/conftest.py
+++ b/test_dag_order/conftest.py
@@ -210,5 +210,5 @@ def stale_sc(plan_reconfigure: DeploymentModel) -> set[str]:
     """Set of stale service_components"""
     sc: set[str] = set()
     for operation in plan_reconfigure.operations:
-        sc.add(OperationName.from_name(operation.operation).entity.name)
+        sc.add(OperationName.from_str(operation.operation).entity.name)
     return sc

--- a/tests/unit/core/test_collection_reader.py
+++ b/tests/unit/core/test_collection_reader.py
@@ -18,7 +18,6 @@ from tdp.core.constants import (
     DEFAULT_VARS_DIRECTORY_NAME,
     PLAYBOOKS_DIRECTORY_NAME,
 )
-from tdp.core.entities.operation import DagOperation
 from tests.conftest import generate_collection_at_path
 from tests.unit.core.models.test_deployment_log import (
     MockInventoryReader,
@@ -148,14 +147,10 @@ def test_collection_reader_read_dag_nodes(mock_empty_collection_reader: Path):
     )
     dag_nodes = list(collection_reader.read_dag_nodes())
     assert len(dag_nodes) == 2
-    assert (
-        DagOperation.from_name(name="s1_c1_a", depends_on=frozenset({"sx_cx_a"}))
-        in dag_nodes
-    )
-    assert (
-        DagOperation.from_name(name="s2_c2_a", depends_on=frozenset({"s1_c1_a"}))
-        in dag_nodes
-    )
+    assert dag_nodes[0].name == "s1_c1_a"
+    assert dag_nodes[0].depends_on == frozenset({"sx_cx_a"})
+    assert dag_nodes[1].name == "s2_c2_a"
+    assert dag_nodes[1].depends_on == frozenset({"s1_c1_a"})
 
 
 def test_collection_reader_read_dag_nodes_empty_file(

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -1,20 +1,27 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import dataclass
+
 import pytest
 
-from tdp.core.entities.operation import Operation
+from tdp.core.entities.operation import Operation, OperationName
 from tdp.core.filters import FilterFactory, GlobFilterStrategy, RegexFilterStrategy
 from tdp.core.models.enums import FilterTypeEnum
+
+
+@dataclass(frozen=True)
+class MockOperation(Operation):
+    pass
 
 
 @pytest.fixture
 def operations():
     return [
-        Operation("service1_component1_config"),
-        Operation("service1_component1_start"),
-        Operation("service1_component2_config"),
-        Operation("service2_component1_start"),
+        MockOperation(OperationName.from_str("service1_component1_config")),
+        MockOperation(OperationName.from_str("service1_component1_start")),
+        MockOperation(OperationName.from_str("service1_component2_config")),
+        MockOperation(OperationName.from_str("service2_component1_start")),
     ]
 
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Transform the `Operation` class to an abstract class that is declined in several implementations:

- `PlaybookOperation(Operation)`
- `OperationNoop(Operation, ABC)`
- `DagOperation(Operation, ABC)`
- `DagOperationNoop(DagOperation, OperationNoop)`
- `DagOperationWithPlaybook(DagOperation, PlaybookOperation)`
- `ForgedDagOperation(DagOperation, ABC)`
- `ForgedDagOperationNoop(DagOperationNoop, ForgedDagOperation)`
- `ForgedDagOperationWithPlaybook(DagOperationWithPlaybook, ForgedDagOperation)`
- `OtherPlaybookOperation(PlaybookOperation)`

The instanciation of the above classes is now ONLY done by the `Collections` class initialization, nowhere else.

The `Collections` class now only exposes a single dict with all available operations, all other previous operations properties are removed (e.g. `dag_operations`, `other_operations`, etc.). Specific operation types can now be obtained using the new `Operations` implementation (available at `Collections.operations`) which define a `get_by_class` method. For example, to retrieve a list of all operation from the DAG that are not forged during the `Collections` initialization:

```py
collections.operations.get_by_class(include=DagOperation, exclude=ForgedOperation)
```

`Collections` and `Operation` usage in the code have been refactored to match those new definitions, without affecting the existing logic.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
