### PR TITLE
refactor: remove OperationName.clone method

### DIFF
--- a/tdp/core/collections/collections.py
+++ b/tdp/core/collections/collections.py
@@ -132,7 +132,7 @@ class Collections:
             operations.add(operation)
             # 2. Forge restart and stop operations from start operations
             if operation.name.action == "start":
-                restart_operation_name = operation.name.clone("restart")
+                restart_operation_name = OperationName(operation.name.entity, "restart")
                 operations.add(
                     ForgedDagOperation.create(
                         operation_name=restart_operation_name,
@@ -140,7 +140,7 @@ class Collections:
                         playbook=self._playbooks.get(str(restart_operation_name)),
                     )
                 )
-                stop_operation_name = operation.name.clone("stop")
+                stop_operation_name = OperationName(operation.name.entity, "stop")
                 operations.add(
                     ForgedDagOperation.create(
                         operation_name=stop_operation_name,

--- a/tdp/core/entities/operation.py
+++ b/tdp/core/entities/operation.py
@@ -61,17 +61,6 @@ class OperationName:
         entity = parse_entity_name(entity_name)
         return cls(entity, action_name)
 
-    def clone(self, action: str) -> OperationName:
-        """Clone the operation name with a new action.
-
-        Args:
-            action: The new action name.
-
-        Returns:
-            A new OperationName object with the same entity and the new action.
-        """
-        return OperationName(entity=self.entity, action=action)
-
     def __repr__(self):
         return self.name
 
@@ -330,7 +319,6 @@ T = TypeVar("T", bound=Operation)
 
 
 class Operations(MutableMapping[Union[OperationName, str], Operation]):
-
     def __init__(self) -> None:
         self._inner = {}
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Remove the `OperationName.clone` method. A clone method shouldn't take any argument, this was a misconception.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
