### PR TITLE
fix: test_collection_reader_read_dag_nodes failure

### DIFF
--- a/tdp/core/collections/collection_reader.py
+++ b/tdp/core/collections/collection_reader.py
@@ -62,7 +62,7 @@ class TDPLibDagNodeModel(BaseModel):
         noop: Whether the operation is a noop.
     """
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     name: str
     depends_on: frozenset[str] = frozenset()

--- a/tests/unit/core/test_collection_reader.py
+++ b/tests/unit/core/test_collection_reader.py
@@ -11,6 +11,7 @@ from tdp.core.collections.collection_reader import (
     MissingMandatoryDirectoryError,
     PathDoesNotExistsError,
     PathIsNotADirectoryError,
+    TDPLibDagNodeModel,
     read_hosts_from_playbook,
 )
 from tdp.core.constants import (
@@ -145,12 +146,12 @@ def test_collection_reader_read_dag_nodes(mock_empty_collection_reader: Path):
     - s1_c1_a
 """
     )
-    dag_nodes = list(collection_reader.read_dag_nodes())
-    assert len(dag_nodes) == 2
-    assert dag_nodes[0].name == "s1_c1_a"
-    assert dag_nodes[0].depends_on == frozenset({"sx_cx_a"})
-    assert dag_nodes[1].name == "s2_c2_a"
-    assert dag_nodes[1].depends_on == frozenset({"s1_c1_a"})
+    assert set(collection_reader.read_dag_nodes()) == set(
+        [
+            TDPLibDagNodeModel(name="s1_c1_a", depends_on=frozenset(["sx_cx_a"])),
+            TDPLibDagNodeModel(name="s2_c2_a", depends_on=frozenset(["s1_c1_a"])),
+        ]
+    )
 
 
 def test_collection_reader_read_dag_nodes_empty_file(


### PR DESCRIPTION
The `TDPLibDagNodeModel` Pydantic model should be frozen as it is exclusively used to read dag nodes informations from files.

Freezing this model makes it hashable. Thus, it allows to fix the failing test using `set`s to compare the dag nodes read (node order should NOT matter in the definition files, order logic is exclusively based on the `depends_on` property).

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
