### PR TITLE
Add repo path information to `GitRepository` errors

### DIFF
--- a/tdp/core/repository/git_repository.py
+++ b/tdp/core/repository/git_repository.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
@@ -18,6 +19,19 @@ from tdp.core.repository.repository import (
 from tdp.core.types import PathLike
 
 logger = logging.getLogger(__name__)
+
+
+def with_repo_path(func):
+    """Decorator to annotate exceptions with the repository path."""
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except Exception as e:
+            raise type(e)(f"[Repo: {self.path}] {e}").with_traceback(e.__traceback__)
+
+    return wrapper
 
 
 class GitRepository(Repository):
@@ -44,6 +58,7 @@ class GitRepository(Repository):
             with Repo.init(path, mkdir=True):
                 return GitRepository(path)
 
+    @with_repo_path
     @contextmanager
     def validate(self, msg: str) -> Generator[GitRepository, None, None]:
         with self._lock:
@@ -60,6 +75,7 @@ class GitRepository(Repository):
             commit = self._repo.index.commit(msg)
             logger.info(f"commit: [{commit.hexsha}] {msg}")
 
+    @with_repo_path
     def add_for_validation(self, paths: Iterable[PathLike]) -> None:
         logger.debug(paths)
         logger.debug(list(paths))
@@ -67,15 +83,18 @@ class GitRepository(Repository):
             self._repo.index.add(list(paths))
             logger.debug(f"{', '.join([str(p) for p in paths])} staged")
 
+    @with_repo_path
     def current_version(self) -> str:
         try:
             return str(self._repo.head.commit)
         except ValueError as e:
             raise NoVersionYet from e
 
+    @with_repo_path
     def is_clean(self) -> bool:
         return not self._repo.is_dirty(untracked_files=True)
 
+    @with_repo_path
     def is_file_modified(self, commit: str, path: PathLike) -> bool:
         with self._lock:
             diff_index = self._repo.head.commit.diff(commit)
@@ -84,5 +103,6 @@ class GitRepository(Repository):
                     return True
             return False
 
+    @with_repo_path
     def restore_file(self, file_names: str) -> None:
         self._repo.index.checkout(paths=[file_names], force=True)


### PR DESCRIPTION
Add the repo path to the stack trace whenever an error happend in a GitRepository method.

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

Replace #621

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

As the lib manages multiple repositories, we should know from which repository an error occurs to facilitate debugging.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
