### PR TITLE
Rename `--overrides` option to `--conf`

### DIFF
--- a/tdp/cli/commands/init.py
+++ b/tdp/cli/commands/init.py
@@ -14,7 +14,7 @@ from tdp.cli.params import (
     validate_option,
     vars_option,
 )
-from tdp.cli.params.overrides_option import overrides_option
+from tdp.cli.params.conf_option import conf_option
 
 if TYPE_CHECKING:
     from sqlalchemy import Engine
@@ -23,13 +23,13 @@ if TYPE_CHECKING:
 
 
 @click.command()
-@overrides_option
+@conf_option
 @collections_option
 @database_dsn_option
 @validate_option
 @vars_option(exists=False)
 def init(
-    overrides: tuple[Path],
+    conf: tuple[Path],
     collections: Collections,
     db_engine: Engine,
     validate: bool,
@@ -42,5 +42,5 @@ def init(
 
     init_database(db_engine)
     ClusterVariables.initialize_cluster_variables(
-        collections, vars, overrides, validate=validate
+        collections, vars, conf, validate=validate
     )

--- a/tdp/cli/commands/vars/update.py
+++ b/tdp/cli/commands/vars/update.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING
 import click
 
 from tdp.cli.params.collections_option import collections_option
+from tdp.cli.params.conf_option import conf_option
 from tdp.cli.params.database_dsn_option import database_dsn_option
-from tdp.cli.params.overrides_option import overrides_option
 from tdp.cli.params.validate_option import validate_option
 from tdp.cli.params.vars_option import vars_option
 from tdp.core.constants import DEFAULT_VALIDATION_MESSAGE, VALIDATION_MESSAGE_FILE
@@ -39,13 +39,13 @@ logger = logging.getLogger(__name__)
     help="Name of the file containing a custom validation message to read in each imported service. When multiple validations message are provided (default --validation-message and/or service imported from multiple import directories), they will be concatenated.",
     default=VALIDATION_MESSAGE_FILE,
 )
-@overrides_option
+@conf_option
 @vars_option
 @database_dsn_option
 @collections_option
 @validate_option
 def update(
-    overrides: tuple[pathlib.Path],
+    conf: tuple[pathlib.Path],
     vars: pathlib.Path,
     db_engine: Engine,
     collections: Collections,
@@ -65,7 +65,7 @@ def update(
     cluster_variables = ClusterVariables.get_cluster_variables(collections, vars)
     try:
         cluster_variables.update(
-            overrides,
+            conf,
             validate=validate,
             validation_msg_file_name=msg_file,
             base_validation_msg=msg,

--- a/tdp/cli/params/conf_option.py
+++ b/tdp/cli/params/conf_option.py
@@ -7,13 +7,13 @@ import click
 from click.decorators import FC
 
 
-def overrides_option(func: FC) -> FC:
-    """Click option that adds an overrides option to the command."""
+def conf_option(func: FC) -> FC:
+    """Add the `--conf` option to a Click command."""
     return click.option(
-        "--overrides",
-        envvar="TDP_OVERRIDES",
+        "--conf",
+        envvar="TDP_CONF",
         required=False,
         type=click.Path(exists=True, resolve_path=True, path_type=pathlib.Path),
         multiple=True,
-        help="Path to TDP variables overrides. Can be used multiple times. Last one takes precedence.",
+        help="Path to the user variable configuration directory. Can be used multiple times. Last one takes precedence.",
     )(func)

--- a/tdp/core/variables/cluster_variables.py
+++ b/tdp/core/variables/cluster_variables.py
@@ -58,7 +58,10 @@ class ClusterVariables(Mapping[str, ServiceVariables]):
         override_folders: Optional[Iterable[PathLike]] = None,
         validate: bool = False,
     ) -> ClusterVariables:
-        """Initializes ClusterVariables by applying overrides and performing commits per input path."""
+        """Initializes ClusterVariables at vars using the base vars from the collections and optional overrides.
+
+        If a service already exists in the vars directory, it will not be re-initialized.
+        """
         tdp_vars = Path(tdp_vars)
         override_folders = override_folders or []
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

Rename the `--overrides` option to `--conf` to clarify the fact that user configuration should be passed through this option.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
