### PR TITLE
`init` creates vars directory if it does not exists

### DIFF
--- a/tdp/cli/commands/init.py
+++ b/tdp/cli/commands/init.py
@@ -40,6 +40,10 @@ def init(
     from tdp.core.models import init_database
     from tdp.core.variables import ClusterVariables
 
+    if not vars.exists():
+        vars.mkdir(parents=True)
+        click.echo(f"Created TDP variables directory: {vars}")
+
     init_database(db_engine)
     ClusterVariables.initialize_cluster_variables(
         collections, vars, conf, validate=validate

--- a/tdp/cli/params/vars_option.py
+++ b/tdp/cli/params/vars_option.py
@@ -20,7 +20,14 @@ def vars_option(func: Optional[FC] = None, *, exists=True) -> Callable[[FC], FC]
             "--vars",
             envvar="TDP_VARS",
             required=True,
-            type=click.Path(resolve_path=True, path_type=Path, exists=exists),
+            type=click.Path(
+                resolve_path=True,
+                path_type=Path,
+                exists=exists,
+                file_okay=False,
+                dir_okay=True,
+                writable=True,
+            ),
             help="Path to the TDP variables.",
             is_eager=True,  # This option is used by other options, so we need to parse it first
         )(fn)

--- a/tdp/core/variables/cluster_variables.py
+++ b/tdp/core/variables/cluster_variables.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -63,6 +64,12 @@ class ClusterVariables(Mapping[str, ServiceVariables]):
         If a service already exists in the vars directory, it will not be re-initialized.
         """
         tdp_vars = Path(tdp_vars)
+        if not tdp_vars.exists():
+            raise FileNotFoundError(f"{tdp_vars} does not exist.")
+        if not tdp_vars.is_dir():
+            raise NotADirectoryError(f"{tdp_vars} is not a directory.")
+        if not os.access(tdp_vars, os.W_OK):
+            raise PermissionError(f"{tdp_vars} is not writable.")
         override_folders = override_folders or []
 
         current = cls.get_cluster_variables(collections, tdp_vars)


### PR DESCRIPTION
This pull request introduces several changes to improve the handling and validation of the TDP variables directory across multiple files. Key updates include stricter validation of paths, enhanced error handling, and improved initialization logic.

### Path validation in the cli:

* [`tdp/cli/params/vars_option.py`](diffhunk://#diff-494099f597cd7735a39c885d27fd81aa50b4e389b377f070386599d75cedce5aL23-R30): Updated the `--vars` parameter type to enforce stricter validation, ensuring the path is a writable directory and disallowing file paths.
* [`tdp/cli/commands/init.py`](diffhunk://#diff-7cacdf5bad9e356bbc332e9181df042d31152d4769c705c7acbebb7c7dddf22bR43-R46): Modified the `init` function to create the TDP variables directory if it does not exist, ensuring smoother initialization and providing user feedback.

### Path validation in core:

* [`tdp/core/variables/cluster_variables.py`](diffhunk://#diff-1dd6c0f93030455b053badd72d3e107743b262234c413c94c7421c3263a2788bR67-R72): Added checks in `initialize_cluster_variables` to raise specific errors (`FileNotFoundError`, `NotADirectoryError`, `PermissionError`) if the provided `tdp_vars` path does not exist, is not a directory, or is not writable.


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
