### PR TITLE
Remove SERVICE and COMPONENT validation from CLI callbacks

### DIFF
--- a/tdp/cli/commands/status/generate_stales.py
+++ b/tdp/cli/commands/status/generate_stales.py
@@ -15,6 +15,7 @@ from tdp.cli.params import (
     validate_option,
     vars_option,
 )
+from tdp.cli.utils import validate_service_component
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -48,6 +49,13 @@ def generate_stales(
     from tdp.core.exceptions import ServiceVariablesNotInitializedErrorList
     from tdp.core.variables import ClusterVariables
     from tdp.dao import Dao
+
+    if not service and component:
+        raise click.UsageError(
+            "Component argument cannot be used without a service argument."
+        )
+    elif service:
+        validate_service_component(service, component, collections=collections)
 
     cluster_variables = ClusterVariables.get_cluster_variables(
         collections=collections, tdp_vars=vars, validate=validate

--- a/tdp/cli/commands/status/show.py
+++ b/tdp/cli/commands/status/show.py
@@ -16,6 +16,7 @@ from tdp.cli.params import (
     validate_option,
     vars_option,
 )
+from tdp.cli.utils import validate_service_component
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -89,6 +90,14 @@ def show(
     )
     from tdp.core.variables import ClusterVariables
     from tdp.dao import Dao
+
+    # Validate service and component argument
+    if not service and component:
+        raise click.UsageError(
+            "Component argument cannot be used without a service argument."
+        )
+    elif service:
+        validate_service_component(service, component, collections=collections)
 
     cluster_variables = ClusterVariables.get_cluster_variables(
         collections=collections, tdp_vars=vars, validate=validate

--- a/tdp/cli/utils.py
+++ b/tdp/cli/utils.py
@@ -11,10 +11,24 @@ import click
 from tabulate import tabulate
 
 if TYPE_CHECKING:
+    from tdp.core.collections.collections import Collections
     from tdp.core.entities.hosted_entity_status import HostedEntityStatus
     from tdp.core.models import DeploymentModel
     from tdp.core.models.operation_model import OperationModel
     from tdp.core.variables.cluster_variables import ClusterVariables
+
+
+def validate_service_component(
+    service: str, component: Optional[str] = None, *, collections: Collections
+):
+    """Wraps the validation of service and component arguments to display a
+    user-friendly error message."""
+    try:
+        collections.validate_service_component(service, component)
+    except ValueError as e:
+        raise click.UsageError(
+            f"Invalid SERVICE or COMPONENT argument: {f'{service}_{component}' if component else service}"
+        ) from e
 
 
 def check_services_cleanliness(cluster_variables: ClusterVariables) -> None:

--- a/tdp/core/collections/collections.py
+++ b/tdp/core/collections/collections.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from tdp.core.entities.entity_name import ServiceComponentName
+from tdp.core.entities.entity_name import ServiceComponentName, create_entity_name
 from tdp.core.entities.operation import (
     DagOperationBuilder,
     ForgedDagOperation,
@@ -199,3 +199,13 @@ class Collections:
             if isinstance(operation.name, ServiceComponentName):
                 service.add(operation.name)
         return services_components
+
+    def validate_service_component(
+        self, service: str, component: Optional[str]
+    ) -> None:
+        """Validate that the service and component are registered in the collections."""
+        entity_name = create_entity_name(service, component)
+        if not entity_name in [op.name.entity for op in self.operations.values()]:
+            raise ValueError(
+                f"Entity '{entity_name}' does not exist in the collections."
+            )


### PR DESCRIPTION
This pull request introduces several changes to improve argument validation, enhance error handling, and simplify the codebase in the `tdp` CLI. The key updates include the addition of a centralized utility function for validating service and component arguments, stricter validation for required arguments, and the removal of redundant validation logic. These changes aim to make the code more maintainable and user-friendly.

### Improvements to argument validation:

* Introduced a new `validate_service_component` method defined in the `Collections` class to centralize the validation of services and components. This method is wrapped by an utility function, `validate_service_component`, in `tdp/cli/utils.py` to validate SERVICE and COMPONENT arguments and to user-friendly error messages
* Updated `tdp/cli/commands/status/edit.py`, `generate_stales.py`, and `show.py` to use the new `validate_service_component` function for validating service and component arguments. [[1]](diffhunk://#diff-af77759e2bb89cbb6ad39a947373e039e3910afd49badf99b85c28830da029a7R78-R84) [[2]](diffhunk://#diff-3ec2ea800a64def09a5e16ac202c5e337cda8ed0779f21724b126a5d1fb4b6deR53-R59) [[3]](diffhunk://#diff-0dc71690a0c2abf9549169cd1de2c143e36d82c92e8e8d250eb50238b37c48f8R94-R101)
  * TODO: the `tdp/cli/vars/edit.py` command should be updated to use the new validation helper. Once done, the `Collections.entities` properties will become unused and could be removed.
* Added stricter validation for required arguments, such as making the `service` argument mandatory in the `edit` command. [[1]](diffhunk://#diff-af77759e2bb89cbb6ad39a947373e039e3910afd49badf99b85c28830da029a7L29-R30) [[2]](diffhunk://#diff-af77759e2bb89cbb6ad39a947373e039e3910afd49badf99b85c28830da029a7R78-R84)

### Codebase simplification:

* Simplified the `service_argument_option` and `component_argument_option` decorators in `tdp/cli/params.py` by removing redundant validation logic and delegating validation to the centralized utility function.
* Removed unnecessary `is_eager` parameters in `collections_option` and `vars_option` decorators as they are no longer required by the service and component validation callbacks. [[1]](diffhunk://#diff-a344aaa93d07c73358a23930cd06c2a289463a4a4a90e9329aadd588b4205704L124) [[2]](diffhunk://#diff-a344aaa93d07c73358a23930cd06c2a289463a4a4a90e9329aadd588b4205704L224)

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
