### PR TITLE
Delegate params callback imports

### DIFF
--- a/tdp/cli/params.py
+++ b/tdp/cli/params.py
@@ -110,7 +110,14 @@ def collections_option(func: FC) -> FC:
     Takes multiple paths (required) and transforms them into a Collections object.
     Available as "collections" in the command context.
     """
-    from tdp.core.collections import Collections
+
+    def _create_collections_callback(
+        _ctx: click.Context, _param: click.Parameter, value
+    ):
+        """Click callback that creates a Collections object."""
+        from tdp.core.collections import Collections
+
+        return Collections.from_collection_paths(value)
 
     return click.option(
         "--collection-path",
@@ -119,7 +126,7 @@ def collections_option(func: FC) -> FC:
         required=True,
         multiple=True,
         type=click.Path(resolve_path=True, path_type=pathlib.Path),
-        callback=lambda ctx, param, value: Collections.from_collection_paths(value),
+        callback=_create_collections_callback,
         help="Path to the collection. Can be used multiple times.",
         is_eager=True,  # This option is used by other options, so we need to parse it first
     )(func)
@@ -131,7 +138,11 @@ def database_dsn_option(func: FC) -> FC:
     Return a SQLAlchemy Engine instance, available as "db_engine" in the command context.
     """
 
-    from tdp.core.db import get_engine
+    def _get_engine_callback(_ctx: click.Context, _param: click.Parameter, value):
+        """Click callback that returns a SQLAlchemy Engine instance."""
+        from tdp.core.db import get_engine
+
+        return get_engine(value)
 
     return click.option(
         "db_engine",
@@ -139,7 +150,7 @@ def database_dsn_option(func: FC) -> FC:
         envvar="TDP_DATABASE_DSN",
         required=True,
         type=str,
-        callback=lambda _ctx, _param, value: get_engine(value),
+        callback=_get_engine_callback,
         help=(
             "Database Data Source Name, in sqlalchemy driver form "
             "example: sqlite:////data/tdp.db or sqlite+pysqlite:////data/tdp.db. "


### PR DESCRIPTION
This pull request refactors callback functions in `tdp/cli/params.py` to further delegate any imports from the `core` part of the lib. A side effect is also improving code readability and maintainability by replacing inline lambda functions with named functions.

### Refactoring:

* [`tdp/cli/params.py`](diffhunk://#diff-a344aaa93d07c73358a23930cd06c2a289463a4a4a90e9329aadd588b4205704R113-R129): Replaced the inline lambda function in the `collections_option` method with a new `_create_collections_callback` function, which creates a `Collections` object from the provided paths.
* [`tdp/cli/params.py`](diffhunk://#diff-a344aaa93d07c73358a23930cd06c2a289463a4a4a90e9329aadd588b4205704R141-R153): Replaced the inline lambda function in the `database_dsn_option` method with a new `_get_engine_callback` function, which returns a SQLAlchemy Engine instance.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
