### PR TITLE
CLI logging setup with early logger and dynamic log level

### DIFF
--- a/tdp/cli/logger.py
+++ b/tdp/cli/logger.py
@@ -2,34 +2,89 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 
 DEFAULT_LOG_LEVEL = logging.INFO
 
 
-def setup_logging(log_level: str) -> None:
-    """
-    Configure the logging module.
+def _get_numeric_log_level(level_str: str) -> int:
+    """Convert a string log level to its numeric equivalent.
 
-    Parameters:
-        log_level: The desired logging level as a string (e.g., "info").
+    Args:
+        level_str: The log level as a string (e.g., "INFO", "DEBUG")
+
+    Returns:
+        The numeric log level, or DEFAULT_LOG_LEVEL if invalid
     """
-    # Ensure the provided log level is valid, using the default if it is not.
-    numeric_level = getattr(logging, log_level.upper(), None)
+    numeric_level = getattr(logging, level_str.upper(), None)
     if not isinstance(numeric_level, int):
-        print(f"Invalid log level: {log_level}. Using {DEFAULT_LOG_LEVEL} instead.")
-        numeric_level = DEFAULT_LOG_LEVEL
+        return DEFAULT_LOG_LEVEL
+    return numeric_level
 
-    # Create a console handler with the specified log level
+
+def _get_default_log_level() -> int:
+    """Get the default log level from environment or return INFO."""
+    if level_str := os.getenv("TDP_LOG_LEVEL", "").strip().upper():
+        return _get_numeric_log_level(level_str)
+    return DEFAULT_LOG_LEVEL
+
+
+def setup_early_logging() -> None:
+    """
+    Set up early logging configuration before CLI parsing.
+    This ensures logging is available for early callbacks.
+    """
+    # Only configure if not already configured
+    if logging.getLogger().handlers:
+        return
+
+    log_level = _get_default_log_level()
+
+    # Create a console handler with the default log level
     console_handler = logging.StreamHandler()
-    console_handler.setLevel(numeric_level)
+    console_handler.setLevel(log_level)
+
     # Create a formatter and attach it to the handler
     formatter = logging.Formatter(
         "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
     )
     console_handler.setFormatter(formatter)
 
-    # Get the root logger and set its level to the specified level
+    # Get the root logger and set its level
     logger = logging.getLogger()
-    logger.setLevel(numeric_level)
+    logger.setLevel(log_level)
     # Add the console handler to the logger
     logger.addHandler(console_handler)
+
+
+def setup_logging(log_level: str) -> None:
+    """
+    Reconfigure the logging module with user-specified level.
+
+    Parameters:
+        log_level: The desired logging level as a string (e.g., "info").
+    """
+    # Ensure the provided log level is valid, using the default if it is not.
+    numeric_level = _get_numeric_log_level(log_level)
+
+    # Update existing logger configuration
+    logger = logging.getLogger()
+    logger.setLevel(numeric_level)
+
+    # Update all existing handlers
+    for handler in logger.handlers:
+        handler.setLevel(numeric_level)
+
+
+def get_early_logger(name: str) -> logging.Logger:
+    """
+    Get a logger that's guaranteed to work even before CLI parsing.
+
+    Parameters:
+        name: The logger name (usually __name__)
+
+    Returns:
+        A configured logger instance.
+    """
+    setup_early_logging()
+    return logging.getLogger(name)


### PR DESCRIPTION
This pull request introduces enhancements to the logging system in the `tdp` CLI to improve configurability and early logging setup. Key changes include adding support for early logging initialization, refining log level handling, and simplifying the CLI entry point. 

### Logging Enhancements

* Introduced a new function, `setup_early_logging`, to configure logging before CLI parsing, ensuring logs are available for early operations. (`tdp/cli/logger.py`, [tdp/cli/logger.pyR5-R90](diffhunk://#diff-c980d63fdd53225fe9f6fb036b8871c5e8e0fed8b8eeedd5c9042bda0bf94eafR5-R90))
* Added a `get_early_logger` function to retrieve a pre-configured logger for use before full CLI initialization. (`tdp/cli/logger.py`, [tdp/cli/logger.pyR5-R90](diffhunk://#diff-c980d63fdd53225fe9f6fb036b8871c5e8e0fed8b8eeedd5c9042bda0bf94eafR5-R90))
* Updated `setup_logging` to reconfigure log levels dynamically and ensure existing handlers are updated. (`tdp/cli/logger.py`, [tdp/cli/logger.pyR5-R90](diffhunk://#diff-c980d63fdd53225fe9f6fb036b8871c5e8e0fed8b8eeedd5c9042bda0bf94eafR5-R90))

### CLI Improvements

* Replaced direct logging setup in the `cli` function with a `logging_callback` for the `--log-level` option, enabling dynamic logging configuration. (`tdp/cli/__main__.py`, [tdp/cli/__main__.pyL45-R69](diffhunk://#diff-0162a57e33759c76f406e0be7a39701bb99c9dc54b2e22cbcc4d95754eab45efL45-R69))
* Added early logging initialization in the CLI entry point using `get_early_logger`, allowing logs to capture early-stage operations. (`tdp/cli/__main__.py`, [tdp/cli/__main__.pyL20-R23](diffhunk://#diff-0162a57e33759c76f406e0be7a39701bb99c9dc54b2e22cbcc4d95754eab45efL20-R23))

### Log Level Handling

* Introduced `_get_numeric_log_level` and `_get_default_log_level` helper functions to standardize log level parsing and default handling from environment variables. (`tdp/cli/logger.py`, [tdp/cli/logger.pyR5-R90](diffhunk://#diff-c980d63fdd53225fe9f6fb036b8871c5e8e0fed8b8eeedd5c9042bda0bf94eafR5-R90))
* Updated the default value for the `--log-level` option to dynamically use the environment variable or a predefined default. (`tdp/cli/__main__.py`, [tdp/cli/__main__.pyL45-R69](diffhunk://#diff-0162a57e33759c76f406e0be7a39701bb99c9dc54b2e22cbcc4d95754eab45efL45-R69))

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
