### PR TITLE
Simplify CLI entry point by removing `main` function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ postgresql-binary = ["psycopg2-binary"]
 mysql = ["pymysql"]
 
 [tool.poetry.scripts]
-tdp = "tdp.cli.__main__:main"
+tdp = "tdp.cli.__main__:cli"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tdp/cli/__main__.py
+++ b/tdp/cli/__main__.py
@@ -69,19 +69,16 @@ def cli():
     pass
 
 
-def main():
-    cli.add_command(browse)
-    cli.add_command(dag)
-    cli.add_command(default_diff)
-    cli.add_command(deploy)
-    cli.add_command(init)
-    cli.add_command(ops)
-    cli.add_command(plan)
-    cli.add_command(status)
-    cli.add_command(vars)
-
-    cli()
+cli.add_command(browse)
+cli.add_command(dag)
+cli.add_command(default_diff)
+cli.add_command(deploy)
+cli.add_command(init)
+cli.add_command(ops)
+cli.add_command(plan)
+cli.add_command(status)
+cli.add_command(vars)
 
 
 if __name__ == "__main__":
-    main()
+    cli()


### PR DESCRIPTION
This pull request refactors the CLI entry point in the `tdp` project to streamline command execution. The changes involve replacing the `main` function with direct invocation of the `cli` function and updating the `pyproject.toml` configuration accordingly.

### CLI Refactoring:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L47-R47): Updated the CLI entry point from `tdp.cli.__main__:main` to `tdp.cli.__main__:cli` to align with the refactored structure.
* [`tdp/cli/__main__.py`](diffhunk://#diff-0162a57e33759c76f406e0be7a39701bb99c9dc54b2e22cbcc4d95754eab45efL72): Removed the `main` function and replaced its usage with direct invocation of the `cli` function, simplifying the command execution flow. [[1]](diffhunk://#diff-0162a57e33759c76f406e0be7a39701bb99c9dc54b2e22cbcc4d95754eab45efL72) [[2]](diffhunk://#diff-0162a57e33759c76f406e0be7a39701bb99c9dc54b2e22cbcc4d95754eab45efL83-R84)


#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
