### PR TITLE
Remove `Collections.entities`

### DIFF
--- a/tdp/core/collections/collections.py
+++ b/tdp/core/collections/collections.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from tdp.core.entities.entity_name import ServiceComponentName, create_entity_name
+from tdp.core.entities.entity_name import create_entity_name
 from tdp.core.entities.operation import (
     DagOperationBuilder,
     ForgedDagOperation,
@@ -65,7 +65,6 @@ class Collections:
         self._operations = self._generate_operations()
         self._default_var_dirs = self._init_default_vars_dirs()
         self._schemas = self._init_schemas()
-        self._services_components = self._init_entities()
 
     @staticmethod
     def from_collection_paths(
@@ -96,11 +95,6 @@ class Collections:
     def schemas(self) -> dict[str, ServiceSchema]:
         """Mapping of service names with their variable schemas."""
         return self._schemas
-
-    @property
-    def entities(self) -> dict[str, set[ServiceComponentName]]:
-        """Mapping of service names to their set of components."""
-        return self._services_components
 
     def get_version(self, collection_name: str) -> CollectionVersion:
         for collection in self._collection_readers:
@@ -187,18 +181,6 @@ class Collections:
             for schema in collection.read_schemas():
                 schemas.setdefault(schema.service, ServiceSchema()).add_schema(schema)
         return schemas
-
-    def _init_entities(self) -> dict[str, set[ServiceComponentName]]:
-        """Initialize the entities from the collections.
-
-        Needs to be called after the operations are initialized.
-        """
-        services_components: dict[str, set[ServiceComponentName]] = {}
-        for operation in self.operations.values():
-            service = services_components.setdefault(operation.name.service, set())
-            if isinstance(operation.name, ServiceComponentName):
-                service.add(operation.name)
-        return services_components
 
     def validate_service_component(
         self, service: str, component: Optional[str]


### PR DESCRIPTION
This pull request removes the `entities` property from the `Collections` class. The dict returned by this property was false due to a bug in the related initialization method.

### Refactoring of `Collections` class:

* Removed the `_init_entities` method and the `_services_components` attribute, which were previously used to manage service-component mappings. This functionality is now handled directly via operations. (`tdp/core/collections/collections.py`, [[1]](diffhunk://#diff-ecf2baa8dd1e39a034467ce081c9ea234c0a8ebf7b915e0344c2974f64d6116aL68) [[2]](diffhunk://#diff-ecf2baa8dd1e39a034467ce081c9ea234c0a8ebf7b915e0344c2974f64d6116aL100-L104) [[3]](diffhunk://#diff-ecf2baa8dd1e39a034467ce081c9ea234c0a8ebf7b915e0344c2974f64d6116aL191-L202)
* Removed the `entities` property, as it is no longer needed due to the shift to operation-based resolution. (`tdp/core/collections/collections.py`, [tdp/core/collections/collections.pyL100-L104](diffhunk://#diff-ecf2baa8dd1e39a034467ce081c9ea234c0a8ebf7b915e0344c2974f64d6116aL100-L104))

### Updates to `resolve_components` function:

* Refactored the function to resolve service-component relationships directly using operations instead of relying on the removed `entities` property. This simplifies the logic and ensures consistency. (`test_dag_order/helpers.py`, [test_dag_order/helpers.pyL169-R212](diffhunk://#diff-08f285fd2e27bd53f2e368456d205d3661c2ceac321bc95b596b806516f9fb8dL169-R212))
* Improved the function's docstring with detailed explanations and examples for better clarity. (`test_dag_order/helpers.py`, [test_dag_order/helpers.pyL169-R212](diffhunk://#diff-08f285fd2e27bd53f2e368456d205d3661c2ceac321bc95b596b806516f9fb8dL169-R212))

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
