### PR TITLE
Rework test fixtures

### DIFF
--- a/tests/e2e/test_tdp.py
+++ b/tests/e2e/test_tdp.py
@@ -1,0 +1,98 @@
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the main CLI application.
+
+This module tests CLI-level functionality including:
+- Global options (--env, --log-level, --cwd)
+- Command routing and parsing
+- Main CLI help system
+- Cross-command consistency
+"""
+
+import pytest
+
+from tdp.cli.__main__ import cli
+
+
+def test_main_cli_help(runner):
+    """Test that the main CLI shows help with available commands."""
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "Usage: tdp [OPTIONS] COMMAND [ARGS]..." in result.output
+    # Check that main commands are listed
+    assert "init" in result.output
+    assert "deploy" in result.output
+    assert "plan" in result.output
+    assert "status" in result.output
+
+
+def test_main_cli_short_help(runner):
+    """Test that the main CLI supports -h shortcut."""
+    result = runner.invoke(cli, ["-h"])
+    assert result.exit_code == 0
+    assert "Usage: tdp [OPTIONS] COMMAND [ARGS]..." in result.output
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "init",
+        "deploy",
+        "dag",
+        "default-diff",
+        "ops",
+        "browse",
+    ],
+)
+def test_command_help_via_cli(runner, command):
+    """Test that all main commands show help when invoked via main CLI."""
+    result = runner.invoke(cli, [command, "--help"])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+
+
+@pytest.mark.parametrize(
+    "subcommand_group,subcommand",
+    [
+        ("plan", "dag"),
+        ("plan", "ops"),
+        ("plan", "reconfigure"),
+        ("status", "show"),
+        ("status", "edit"),
+        ("vars", "edit"),
+        ("vars", "validate"),
+    ],
+)
+def test_subcommand_help_via_cli(runner, subcommand_group, subcommand):
+    """Test that all subcommands show help when invoked via main CLI."""
+    result = runner.invoke(cli, [subcommand_group, subcommand, "--help"])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+
+
+def test_global_log_level_option(runner):
+    """Test that global --log-level option works."""
+    result = runner.invoke(cli, ["--log-level", "DEBUG", "--help"])
+    assert result.exit_code == 0
+
+
+def test_invalid_command(runner):
+    """Test that invalid commands show appropriate error."""
+    result = runner.invoke(cli, ["invalid-command"])
+    assert result.exit_code != 0
+    assert "No such command" in result.output
+
+
+def test_command_routing_consistency(runner):
+    """Test that command routing works consistently across all commands."""
+    # Test that we can reach nested commands
+    result = runner.invoke(cli, ["plan", "--help"])
+    assert result.exit_code == 0
+    assert "dag" in result.output
+    assert "ops" in result.output
+
+    result = runner.invoke(cli, ["status", "--help"])
+    assert result.exit_code == 0
+    assert "show" in result.output
+    assert "edit" in result.output

--- a/tests/e2e/test_tdp_default_diff.py
+++ b/tests/e2e/test_tdp_default_diff.py
@@ -1,20 +1,11 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.default_diff import default_diff
 
 
-def test_tdp_default_diff(collection_path: Path, vars: Path):
-    args = [
-        "--collection-path",
-        collection_path,
-        "--vars",
-        vars,
-    ]
-    runner = CliRunner()
-    result = runner.invoke(default_diff, args)
+def test_tdp_default_diff(runner, collection_path, vars):
+    result = runner.invoke(
+        default_diff, f"--collection-path {collection_path} --vars {vars}".split()
+    )
     assert result.exit_code == 0, result.output

--- a/tests/e2e/test_tdp_deploy.py
+++ b/tests/e2e/test_tdp_deploy.py
@@ -1,37 +1,36 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from click.testing import CliRunner
-
 from tdp.cli.commands.deploy import deploy
-from tdp.cli.commands.plan.dag import dag
-from tests.e2e.conftest import TDPInitArgs
 
 
-def test_tdp_deploy_mock(
-    tdp_init: TDPInitArgs,
-):
-    runner = CliRunner()
-    result = runner.invoke(
-        dag,
-        [
-            "--collection-path",
-            str(tdp_init.collection_path),
-            "--database-dsn",
-            tdp_init.db_dsn,
-        ],
+def test_tdp_deploy_mock(runner, tdp, collection_path, db_dsn, vars):
+    collection_path.init_dag_directory(
+        {
+            "service": [
+                {"name": "service_install"},
+            ],
+        }
+    )
+    collection_path.init_default_vars_directory(
+        {
+            "service": {
+                "service.yml": {},
+            },
+        }
+    )
+
+    result = tdp(
+        f"init --collection-path {collection_path} --database-dsn {db_dsn} --vars {vars}"
     )
     assert result.exit_code == 0, result.output
+    result = tdp(
+        f"plan dag --collection-path {collection_path} --database-dsn {db_dsn}"
+    )
+    assert result.exit_code == 0, result.output
+
     result = runner.invoke(
         deploy,
-        [
-            "--collection-path",
-            str(tdp_init.collection_path),
-            "--database-dsn",
-            tdp_init.db_dsn,
-            "--vars",
-            str(tdp_init.vars),
-            "--mock-deploy",
-        ],
+        f"--collection-path {collection_path} --database-dsn {db_dsn} --vars {vars}".split(),
     )
     assert result.exit_code == 0, result.output

--- a/tests/e2e/test_tdp_init.py
+++ b/tests/e2e/test_tdp_init.py
@@ -1,25 +1,108 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-from pathlib import Path
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.init import init
+from tdp.core.repository.git_repository import GitRepository
 
 
-def test_tdp_init_db_is_created(collection_path: Path, vars: Path, tmp_path: Path):
-    db_path = tmp_path / "sqlite.db"
-    args = [
-        "--collection-path",
-        str(collection_path),
-        "--database-dsn",
-        "sqlite:///" + str(db_path),
-        "--vars",
-        str(vars),
-    ]
-    runner = CliRunner()
-    result = runner.invoke(init, args)
-    assert os.path.exists(db_path) == True
+def test_tdp_init_missing_collection_path(runner, db_dsn, vars):
+    """Test that the init command fails when collection path is not provided."""
+    result = runner.invoke(init, f"--database-dsn {db_dsn} --vars {vars}".split())
+    assert result.exit_code != 0
+    assert "Error: Missing option '--collection-path'." in result.output
+
+
+def test_tdp_init_missing_database_dsn(runner, collection_path, vars):
+    """Test that the init command fails when database DSN is not provided."""
+    result = runner.invoke(
+        init, f"--collection-path {collection_path} --vars {vars}".split()
+    )
+    assert result.exit_code != 0
+    assert "Error: Missing option '--database-dsn'." in result.output
+
+
+def test_tdp_init_missing_vars_dir(runner, collection_path, db_dsn):
+    """Test that the init command fails when vars directory is not provided."""
+    result = runner.invoke(
+        init, f"--collection-path {collection_path} --database-dsn {db_dsn}".split()
+    )
+    assert result.exit_code != 0
+    assert "Error: Missing option '--vars'." in result.output
+
+
+def test_tdp_init_variables_single_collection(runner, vars, db_dsn, collection_path):
+    """Test that the init command runs successfully with valid parameters and service."""
+    collection = collection_path
+    collection.init_default_vars_directory(
+        {
+            "s1": {
+                "s1.yml": {"foo": "value"},
+            }
+        }
+    )
+
+    result = runner.invoke(
+        init,
+        f"--collection-path {collection} --database-dsn {db_dsn} --vars {vars}".split(),
+    )
     assert result.exit_code == 0, result.output
+    assert vars.joinpath("s1", "s1.yml").exists()
+    assert GitRepository(vars / "s1"), "Git repository should be initialized in vars/s1"
+    repo = GitRepository(vars / "s1")
+    assert repo.is_clean(), "Git repository should be clean after initialization"
+    assert repo.current_version(), "Git repository should have a current version"
+    assert len(list(repo._repo.iter_commits())) == 1, (
+        "Git repository should have one commit after initialization"
+    )
+    assert vars.joinpath("s1", "s1.yml").read_text() == "foo: value\n"
+
+
+def test_tdp_init_variables_multiple_collections(
+    runner, collection_path_factory, vars, db_dsn
+):
+    """Test that the init command runs successfully with valid parameters and multiple collections."""
+    collection1 = collection_path_factory()
+    collection1.init_default_vars_directory(
+        {
+            "s1": {
+                "s1.yml": {"foo": "value", "bar": "other value"},
+            }
+        }
+    )
+    collection2 = collection_path_factory()
+    collection2.init_default_vars_directory(
+        {
+            "s1": {
+                "s1.yml": {"foo": "new value"},
+            },
+            "s2": {
+                "s2_c1.yml": {"baz": "value"},
+            },
+        }
+    )
+
+    result = runner.invoke(
+        init,
+        f"--collection-path {collection1} --collection-path {collection2} --database-dsn {db_dsn} --vars {vars}".split(),
+    )
+    assert result.exit_code == 0, result.output
+    assert vars.joinpath("s1", "s1.yml").exists()
+    assert vars.joinpath("s2", "s2_c1.yml").exists()
+    assert GitRepository(vars / "s1"), "Git repository should be initialized in vars/s1"
+    assert GitRepository(vars / "s2"), "Git repository should be initialized in vars/s2"
+    repo_s1 = GitRepository(vars / "s1")
+    repo_s2 = GitRepository(vars / "s2")
+    assert repo_s1.is_clean(), "Git repository s1 should be clean after initialization"
+    assert repo_s2.is_clean(), "Git repository s2 should be clean after initialization"
+    assert repo_s1.current_version(), "Git repository s1 should have a current version"
+    assert repo_s2.current_version(), "Git repository s2 should have a current version"
+    assert len(list(repo_s1._repo.iter_commits())) == 2, (
+        "Git repository s1 should have one commit after initialization"
+    )
+    assert len(list(repo_s2._repo.iter_commits())) == 1, (
+        "Git repository s2 should have one commit after initialization"
+    )
+    assert (
+        vars.joinpath("s1", "s1.yml").read_text()
+        == "foo: new value\nbar: other value\n"
+    )

--- a/tests/e2e/test_tdp_ops.py
+++ b/tests/e2e/test_tdp_ops.py
@@ -1,15 +1,9 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.ops import ops
 
 
-def test_tdp_nodes(collection_path: Path):
-    args = ["--collection-path", collection_path]
-    runner = CliRunner()
-    result = runner.invoke(ops, args)
+def test_tdp_nodes(runner, collection_path):
+    result = runner.invoke(ops, f"--collection-path {collection_path}".split())
     assert result.exit_code == 0, result.output

--- a/tests/e2e/test_tdp_plan_dag.py
+++ b/tests/e2e/test_tdp_plan_dag.py
@@ -1,24 +1,23 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.plan.dag import dag
-from tests.e2e.conftest import TDPInitArgs
 
 
-def test_tdp_plan_dag(
-    tdp_init: TDPInitArgs,
-):
-    runner = CliRunner()
+def test_tdp_plan_dag(tdp, runner, collection_path, db_dsn, vars):
+    collection_path.init_dag_directory(
+        {
+            "service": [
+                {"name": "service_install"},
+            ]
+        }
+    )
+    result = tdp(
+        f"init --collection-path {collection_path} --vars {vars} --database-dsn {db_dsn}"
+    )
+    assert result.exit_code == 0, result.output
+
     result = runner.invoke(
-        dag,
-        [
-            "--collection-path",
-            str(tdp_init.collection_path),
-            "--database-dsn",
-            tdp_init.db_dsn,
-        ],
+        dag, f"--collection-path {collection_path} --database-dsn {db_dsn}".split()
     )
     assert result.exit_code == 0, result.output

--- a/tests/e2e/test_tdp_plan_ops.py
+++ b/tests/e2e/test_tdp_plan_ops.py
@@ -1,25 +1,24 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.plan.ops import ops
-from tests.e2e.conftest import TDPInitArgs
 
 
-def test_tdp_plan_run(
-    tdp_init: TDPInitArgs,
-):
-    runner = CliRunner()
+def test_tdp_plan_run(tdp, vars, runner, collection_path, db_dsn):
+    collection_path.init_dag_directory(
+        {
+            "service": [
+                {"name": "service_install"},
+            ]
+        }
+    )
+    result = tdp(
+        f"init --collection-path {collection_path} --vars {vars} --database-dsn {db_dsn}"
+    )
+    assert result.exit_code == 0, result.output
+
     result = runner.invoke(
         ops,
-        [
-            "--collection-path",
-            str(tdp_init.collection_path),
-            "--database-dsn",
-            tdp_init.db_dsn,
-            "service_install",
-        ],
+        f"--collection-path {collection_path} --database-dsn {db_dsn} service_install".split(),
     )
     assert result.exit_code == 0, result.output

--- a/tests/e2e/test_tdp_plan_reconfigure.py
+++ b/tests/e2e/test_tdp_plan_reconfigure.py
@@ -1,26 +1,12 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.plan.reconfigure import reconfigure
-from tests.e2e.conftest import TDPInitArgs
 
 
-def test_tdp_plan_reconfigure(
-    tdp_init: TDPInitArgs,
-):
-    runner = CliRunner()
+def test_tdp_plan_reconfigure(runner, collection_path, db_dsn):
     result = runner.invoke(
         reconfigure,
-        [
-            "--collection-path",
-            str(tdp_init.collection_path),
-            "--database-dsn",
-            tdp_init.db_dsn,
-        ],
+        f"--collection-path {collection_path} --database-dsn {db_dsn}".split(),
     )
-    assert result.exit_code == 1, (
-        result.output
-    )  # No stale components, hence nothing to reconfigure.
+    assert result.exit_code == 1, result.output

--- a/tests/e2e/test_tdp_plan_resume.py
+++ b/tests/e2e/test_tdp_plan_resume.py
@@ -1,25 +1,16 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-
-from click.testing import CliRunner
-
-from tdp.cli.commands.plan.dag import dag
 from tdp.cli.commands.plan.resume import resume
-from tests.e2e.conftest import TDPInitArgs
 
 
-def test_tdp_plan_resume_nothing_to_resume(
-    tdp_init: TDPInitArgs,
-):
-    common_args = [
-        "--collection-path",
-        str(tdp_init.collection_path),
-        "--database-dsn",
-        tdp_init.db_dsn,
-    ]
-    runner = CliRunner()
-    result = runner.invoke(dag, common_args)
+def test_tdp_plan_resume_nothing_to_resume(tdp, runner, collection_path, db_dsn, vars):
+    result = tdp(
+        f"init --collection-path {collection_path} --vars {vars} --database-dsn {db_dsn}"
+    )
     assert result.exit_code == 0, result.output
-    result = runner.invoke(resume, common_args)
+
+    result = runner.invoke(
+        resume, f"--collection-path {collection_path} --database-dsn {db_dsn}".split()
+    )
     assert result.exit_code == 1, result.output  # No deployment to resume.

--- a/tests/e2e/test_tdp_status_edit.py
+++ b/tests/e2e/test_tdp_status_edit.py
@@ -1,29 +1,23 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.status.edit import edit
-from tests.e2e.conftest import TDPInitArgs
 
 
-def test_tdp_status_edit(
-    tdp_init: TDPInitArgs,
-):
-    runner = CliRunner()
+def test_tdp_status_edit(tdp, runner, db_dsn, collection_path, vars):
+    collection_path.init_dag_directory(
+        {
+            "service": [
+                {"name": "service_install"},
+            ],
+        }
+    )
+    result = tdp(
+        f"init --collection-path {collection_path} --vars {vars} --database-dsn {db_dsn}"
+    )
+    assert result.exit_code == 0, result.output
     result = runner.invoke(
         edit,
-        [
-            "--collection-path",
-            str(tdp_init.collection_path),
-            "--database-dsn",
-            tdp_init.db_dsn,
-            "--vars",
-            str(tdp_init.vars),
-            "service",
-            "--host",
-            "localhost",
-        ],
+        f"--collection-path {collection_path} --database-dsn {db_dsn} --vars {vars} service --host localhost".split(),
     )
     assert result.exit_code == 0, result.output

--- a/tests/e2e/test_tdp_status_generate_stales.py
+++ b/tests/e2e/test_tdp_status_generate_stales.py
@@ -1,26 +1,17 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.status.generate_stales import generate_stales
-from tests.e2e.conftest import TDPInitArgs
 
 
-def test_tdp_status_edit(
-    tdp_init: TDPInitArgs,
-):
-    runner = CliRunner()
+def test_tdp_status_edit(tdp, runner, collection_path, db_dsn, vars):
+    result = tdp(
+        f"init --collection-path {collection_path} --vars {vars} --database-dsn {db_dsn}"
+    )
+    assert result.exit_code == 0, result.output
+
     result = runner.invoke(
         generate_stales,
-        [
-            "--collection-path",
-            str(tdp_init.collection_path),
-            "--database-dsn",
-            tdp_init.db_dsn,
-            "--vars",
-            str(tdp_init.vars),
-        ],
+        f"--collection-path {collection_path} --database-dsn {db_dsn} --vars {vars}".split(),
     )
     assert result.exit_code == 0, result.output

--- a/tests/e2e/test_tdp_status_show.py
+++ b/tests/e2e/test_tdp_status_show.py
@@ -1,26 +1,17 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.status.show import show
-from tests.e2e.conftest import TDPInitArgs
 
 
-def test_tdp_status_edit(
-    tdp_init: TDPInitArgs,
-):
-    runner = CliRunner()
+def test_tdp_status_edit(tdp, runner, collection_path, db_dsn, vars):
+    result = tdp(
+        f"init --collection-path {collection_path} --vars {vars} --database-dsn {db_dsn}"
+    )
+    assert result.exit_code == 0, result.output
+
     result = runner.invoke(
         show,
-        [
-            "--collection-path",
-            str(tdp_init.collection_path),
-            "--database-dsn",
-            tdp_init.db_dsn,
-            "--vars",
-            str(tdp_init.vars),
-        ],
+        f"--collection-path {collection_path} --database-dsn {db_dsn} --vars {vars}".split(),
     )
     assert result.exit_code == 0, result.output

--- a/tests/e2e/test_tdp_vars_validate.py
+++ b/tests/e2e/test_tdp_vars_validate.py
@@ -1,15 +1,11 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
-
-from click.testing import CliRunner
-
 from tdp.cli.commands.vars.validate import validate
 
 
-def test_tdp_validate(collection_path: Path, vars: Path):
-    args = ["--collection-path", collection_path, "--vars", vars]
-    runner = CliRunner()
-    result = runner.invoke(validate, args)
+def test_tdp_validate(runner, collection_path, vars):
+    result = runner.invoke(
+        validate, f"--collection-path {collection_path} --vars {vars}".split()
+    )
     assert result.exit_code == 0, result.output

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,42 @@
+# Copyright 2025 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session
+
+from tdp.core.db import get_engine, get_session
+from tdp.core.models import init_database
+from tdp.core.models.base_model import BaseModel
+
+
+@pytest.fixture()
+def db_engine(db_dsn: str) -> Generator[Engine, None, None]:
+    """Fixture to create a database engine.
+
+    This fixture initializes the database schema and returns an engine that can be used
+    in tests. It also ensures that the database is cleared after the test completes.
+    """
+    engine = get_engine(db_dsn)
+    init_database(engine)
+    try:
+        yield engine
+    finally:
+        BaseModel.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def db_session(db_engine: Engine) -> Generator[Session, None, None]:
+    """Fixture to create a database session.
+
+    This fixture initializes returns a session that can be used in tests. It also
+    ensures that the session is closed after the test completes.
+    """
+    session = get_session(db_engine)
+    try:
+        yield session
+    finally:
+        session.close()

--- a/tests/unit/core/models/test_models.py
+++ b/tests/unit/core/models/test_models.py
@@ -4,18 +4,13 @@
 import logging
 from datetime import datetime, timedelta
 
-import pytest
-from sqlalchemy.engine import Engine
-
 from tdp.core.models import DeploymentModel, OperationModel, SCHStatusLogModel
-from tests.conftest import create_session
 
 logger = logging.getLogger(__name__)
 
 
 # TODO: add some status logs
-@pytest.mark.parametrize("db_engine", [True], indirect=True)
-def test_create_deployment(db_engine: Engine):
+def test_create_deployment(db_session):
     deployment = DeploymentModel(
         options={
             "sources": ["source1", "source2"],
@@ -54,29 +49,28 @@ def test_create_deployment(db_engine: Engine):
     logger.info(operation_rec)
     logger.info(component_version_log)
 
-    with create_session(db_engine) as session:
-        session.add(deployment)
-        session.commit()
+    db_session.add(deployment)
+    db_session.commit()
 
-        result = session.get(DeploymentModel, deployment.id)
+    result = db_session.get(DeploymentModel, deployment.id)
 
-        logger.info(result)
-        assert result is not None
-        assert result.options == {
-            "sources": ["source1", "source2"],
-            "targets": ["target1", "target2"],
-            "filter_expression": ".*",
-            "filter_type": "glob",
-            "hosts": ["host1", "host2"],
-            "restart": False,
-        }
-        assert result.state == "Success"
-        assert result.deployment_type == "Dag"
+    logger.info(result)
+    assert result is not None
+    assert result.options == {
+        "sources": ["source1", "source2"],
+        "targets": ["target1", "target2"],
+        "filter_expression": ".*",
+        "filter_type": "glob",
+        "hosts": ["host1", "host2"],
+        "restart": False,
+    }
+    assert result.state == "Success"
+    assert result.deployment_type == "Dag"
 
-        logger.info(result.operations)
-        assert len(result.operations) == 1
-        assert result.operations[0].operation_order == 1
-        assert result.operations[0].operation == "start_target1"
-        assert result.operations[0].host == "host1"
-        assert result.operations[0].state == "Success"
-        assert result.operations[0].logs == b"operation log"
+    logger.info(result.operations)
+    assert len(result.operations) == 1
+    assert result.operations[0].operation_order == 1
+    assert result.operations[0].operation == "start_target1"
+    assert result.operations[0].host == "host1"
+    assert result.operations[0].state == "Success"
+    assert result.operations[0].logs == b"operation log"

--- a/tests/unit/test_dao.py
+++ b/tests/unit/test_dao.py
@@ -1,178 +1,42 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
-import random
-import string
-from typing import List, Optional
+from typing import Any
 
-import pytest
 from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
 
 from tdp.core.models import (
     DeploymentModel,
     OperationModel,
-    SCHStatusLogModel,
-    SCHStatusLogSourceEnum,
 )
+from tdp.core.models.base_model import BaseModel
 from tdp.core.models.enums import DeploymentStateEnum, OperationStateEnum
 from tdp.dao import Dao
-from tests.conftest import assert_equal_values_in_model, create_session
-
-logger = logging.getLogger(__name__)
 
 
-def _generate_version() -> str:
-    """Generate a random version string."""
-    return "".join(
-        random.choice(string.ascii_lowercase + string.digits) for _ in range(6)
-    )
+def assert_equal_values_in_model(model1: Any, model2: Any) -> bool:
+    """SQLAlchemy asserts that two identical objects of type DeclarativeBase parent of the BaseModel class,
+    which is used in TDP as pattern for the table models, are identical if they are compared in the same session,
+    but different if compared in two different sessions.
+
+    This function therefore transforms the tables into dictionaries and by parsing the coulumns compares their values.
+    """
+    if isinstance(model1, BaseModel) and isinstance(model2, BaseModel):
+        return model1.to_dict() == model2.to_dict()
+    else:
+        return False
 
 
-def _set_seed(seed: Optional[str] = None) -> None:
-    """Set the seed for random number generation and log the seed."""
-    _seed = seed or _generate_version()  # Generate a random seed
-    random.seed(_seed)
-    logger.info(f"Random seed set to: {_seed}")
-
-
-def _mock_sch_status_log(
-    service: str,
-    component: Optional[str],
-    host: Optional[str],
-    n: int = 50,
-    seed: Optional[str] = None,
-) -> List["SCHStatusLogModel"]:
-    """Generate n mock SCHStatusLog entries."""
-    _set_seed(seed)
-    logs = []
-    for _ in range(n):
-        logs.append(
-            SCHStatusLogModel(
-                service=service,
-                component=component,
-                host=host,
-                source=SCHStatusLogSourceEnum.STALE,
-                running_version=(
-                    _generate_version() if random.choice([True, False]) else None
-                ),
-                configured_version=(
-                    _generate_version() if random.choice([True, False]) else None
-                ),
-                to_config=random.choice([True, False, None]),
-                to_restart=random.choice([True, False, None]),
-            )
+def test_get_deployment(db_session: Session, db_engine: Engine):
+    db_session.add(
+        DeploymentModel(
+            id=1,
+            state=DeploymentStateEnum.RUNNING,
         )
-    return logs
-
-
-def _last_values(
-    logs: List["SCHStatusLogModel"],
-):
-    """Return an SCHStatusLog holding the last non None value for each column from a list of logs."""
-    return (
-        logs[-1].service,
-        logs[-1].component,
-        logs[-1].host,
-        next(
-            (
-                log.running_version
-                for log in reversed(logs)
-                if log.running_version is not None
-            ),
-            None,
-        ),
-        next(
-            (
-                log.configured_version
-                for log in reversed(logs)
-                if log.configured_version is not None
-            ),
-            None,
-        ),
-        next(
-            (log.to_config for log in reversed(logs) if log.to_config is not None), None
-        ),
-        next(
-            (log.to_restart for log in reversed(logs) if log.to_restart is not None),
-            None,
-        ),
     )
+    db_session.commit()
 
-
-@pytest.mark.skip(reason="db_session fixture needs to be reworked.")
-@pytest.mark.parametrize("db_engine", [True], indirect=True)
-def test_single_service_component_status(db_engine: Engine):
-    """Test the get_sch_status query with a single sch."""
-    logs = _mock_sch_status_log("smock", "cmock", "hmock", 5)
-    last_values = _last_values(logs)
-
-    # Use this instead of db_session.add_all() to ensure different timestamps
-    with create_session(db_engine) as session:
-        for log in logs:
-            session.add(log)
-            # Commit at each step to ensure different timestamps
-            session.commit()
-
-    with Dao(db_engine) as dao:
-        assert dao.get_cluster_status() == [last_values]
-
-
-@pytest.mark.skip(reason="db_session fixture needs to be reworked.")
-@pytest.mark.parametrize("db_engine", [True], indirect=True)
-def test_multiple_service_component_status(db_engine: Engine):
-    """Test the get_sch_status query with multiple schs."""
-    classic_component_logs = _mock_sch_status_log("smock", "cmock", "hmock")
-    service_noop_logs = _mock_sch_status_log("smock", None, None)
-    component_noop_logs = _mock_sch_status_log("smock", "cmock", None)
-    service_logs = _mock_sch_status_log("smock", None, "hmock")
-
-    log_lists = [
-        classic_component_logs,
-        service_noop_logs,
-        component_noop_logs,
-        service_logs,
-    ]
-
-    last_values = set([_last_values(log_list) for log_list in log_lists])
-
-    # Create iterators for each log list to step through them.
-    iterators = [iter(log_list) for log_list in log_lists]
-
-    # Fetch the first log from each list. 'None' if the list is empty.
-    next_logs = [next(it, None) for it in iterators]
-
-    # Continue until all logs have been appended.
-    while any(log is not None for log in next_logs):
-        # Get indices of the lists that still have logs left.
-        available_indices = [i for i, log in enumerate(next_logs) if log is not None]
-
-        # Randomly select one of the available log lists.
-        chosen_index = random.choice(available_indices)
-
-        # Append the next log from the chosen list to the database.
-        with create_session(db_engine) as session:
-            session.add(next_logs[chosen_index])
-            # Commit at each step to ensure different timestamps
-            session.commit()
-
-        # Update the next log for the chosen list. 'None' if no more logs are left.
-        next_logs[chosen_index] = next(iterators[chosen_index], None)
-
-    with Dao(db_engine) as dao:
-        assert set(dao.get_cluster_status()) == last_values
-
-
-@pytest.mark.parametrize("db_engine", [True], indirect=True)
-def test_get_deployment(db_engine):
-    with create_session(db_engine) as session:
-        session.add(
-            DeploymentModel(
-                id=1,
-                state=DeploymentStateEnum.RUNNING,
-            )
-        )
-        session.commit()
     with Dao(db_engine) as dao:
         assert assert_equal_values_in_model(
             dao.get_deployment(1),
@@ -183,16 +47,15 @@ def test_get_deployment(db_engine):
         )
 
 
-@pytest.mark.parametrize("db_engine", [True], indirect=True)
-def test_get_planned_deployment(db_engine):
-    with create_session(db_engine) as session:
-        session.add(
-            DeploymentModel(
-                id=1,
-                state=DeploymentStateEnum.PLANNED,
-            )
+def test_get_planned_deployment(db_session: Session, db_engine: Engine):
+    db_session.add(
+        DeploymentModel(
+            id=1,
+            state=DeploymentStateEnum.PLANNED,
         )
-        session.commit()
+    )
+    db_session.commit()
+
     with Dao(db_engine) as dao:
         assert assert_equal_values_in_model(
             dao.get_planned_deployment(),
@@ -203,22 +66,21 @@ def test_get_planned_deployment(db_engine):
         )
 
 
-@pytest.mark.parametrize("db_engine", [True], indirect=True)
-def test_get_last_deployment(db_engine):
-    with create_session(db_engine) as session:
-        session.add(
-            DeploymentModel(
-                id=2,
-                state=DeploymentStateEnum.FAILURE,
-            )
+def test_get_last_deployment(db_session: Session, db_engine: Engine):
+    db_session.add(
+        DeploymentModel(
+            id=2,
+            state=DeploymentStateEnum.FAILURE,
         )
-        session.add(
-            DeploymentModel(
-                id=3,
-                state=DeploymentStateEnum.SUCCESS,
-            )
+    )
+    db_session.add(
+        DeploymentModel(
+            id=3,
+            state=DeploymentStateEnum.SUCCESS,
         )
-        session.commit()
+    )
+    db_session.commit()
+
     with Dao(db_engine) as dao:
         assert assert_equal_values_in_model(
             dao.get_last_deployment(),
@@ -229,22 +91,21 @@ def test_get_last_deployment(db_engine):
         )
 
 
-@pytest.mark.parametrize("db_engine", [True], indirect=True)
-def test_get_deployments(db_engine):
-    with create_session(db_engine) as session:
-        session.add(
-            DeploymentModel(
-                id=1,
-                state=DeploymentStateEnum.SUCCESS,
-            )
+def test_get_deployments(db_session: Session, db_engine: Engine):
+    db_session.add(
+        DeploymentModel(
+            id=1,
+            state=DeploymentStateEnum.SUCCESS,
         )
-        session.add(
-            DeploymentModel(
-                id=2,
-                state=DeploymentStateEnum.PLANNED,
-            )
+    )
+    db_session.add(
+        DeploymentModel(
+            id=2,
+            state=DeploymentStateEnum.PLANNED,
         )
-        session.commit()
+    )
+    db_session.commit()
+
     with Dao(db_engine) as dao:
         assert assert_equal_values_in_model(
             list(dao.get_last_deployments())[0],
@@ -256,19 +117,18 @@ def test_get_deployments(db_engine):
         )
 
 
-@pytest.mark.parametrize("db_engine", [True], indirect=True)
-def test_operation(db_engine):
-    with create_session(db_engine) as session:
-        session.add(DeploymentModel(id=1, state=DeploymentStateEnum.SUCCESS))
-        session.add(
-            OperationModel(
-                deployment_id=1,
-                operation_order=1,
-                operation="test_operation",
-                state=OperationStateEnum.SUCCESS,
-            )
+def test_operation(db_session: Session, db_engine: Engine):
+    db_session.add(DeploymentModel(id=1, state=DeploymentStateEnum.SUCCESS))
+    db_session.add(
+        OperationModel(
+            deployment_id=1,
+            operation_order=1,
+            operation="test_operation",
+            state=OperationStateEnum.SUCCESS,
         )
-        session.commit()
+    )
+    db_session.commit()
+
     with Dao(db_engine) as dao:
         assert assert_equal_values_in_model(
             dao.get_operations_by_name(


### PR DESCRIPTION
This pull request introduces significant refactoring and improvements to the test suite for the TDP CLI application. The changes focus on modularizing the test setup, enhancing reusability, and improving the clarity of test cases. Key updates include the removal of redundant code, the introduction of helper methods, and the addition of new integration tests for the CLI.

### Refactoring and modularization of test fixtures:

* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L5-L12): Removed unused imports and redundant database-related fixtures (`db_engine`, `create_session`, etc.). Introduced modular helper functions (`init_dag_directory`, `init_playbooks_directory`, `init_default_vars_directory`) for creating test collections. Simplified the `generate_collection_at_path` function to use these helpers. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L5-L12) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L21-R60) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L61-L108) [[4]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L117-R149)

* [`tests/e2e/conftest.py`](diffhunk://#diff-824bc3e5c28226a3c0f4581750fa93a7da7001aff9e0ff4aee4131e3edd7b144L6-R107): Replaced the `TDPInitArgs` class with a more flexible `CollectionPath` class, which provides methods for initializing directories. Added a `collection_path_factory` fixture for creating multiple collections in tests. Simplified the `tdp` fixture to invoke CLI commands with a runner.

* Updated existing tests cases to use the new fixtures.

### Enhanced CLI integration tests:

* [`tests/e2e/test_tdp.py`](diffhunk://#diff-42d1570900abb439a05d30edabb766570f61a4d3538f9f6da461fe5ea5af46abR1-R98): Added new tests to validate CLI functionality, including help messages, command routing, and global options. These tests ensure consistent behavior across commands and subcommands.
* Create more complete tests for the `tdp init` command in `tests/e2e/test_tdp_init.py`.

These changes improve the maintainability and scalability of the test suite, making it easier to add new tests and adapt to future changes in the codebase.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
