### PR TITLE
Create `AnsibleLoader`

### DIFF
--- a/tdp/cli/commands/default_diff.py
+++ b/tdp/cli/commands/default_diff.py
@@ -43,8 +43,7 @@ def service_diff(collections: Collections, service):
         collections (Collections): Collections object.
         service (ServiceManager): Service to compare's manager.
     """
-    from ansible.utils.vars import merge_hash
-
+    from tdp.core.ansible_loader import AnsibleLoader
     from tdp.core.variables import Variables
 
     # key: filename with extension, value: PosixPath(filepath)
@@ -80,7 +79,7 @@ def service_diff(collections: Collections, service):
             with Variables(default_service_vars_filepath).open(
                 "r"
             ) as default_variables:
-                default_service_varfile = merge_hash(
+                default_service_varfile = AnsibleLoader.get_merge_hash()(
                     default_service_varfile, default_variables
                 )
 

--- a/tdp/core/ansible_loader.py
+++ b/tdp/core/ansible_loader.py
@@ -1,0 +1,74 @@
+# Copyright 2025 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+
+class AnsibleLoader:
+    """Lazy loader for Ansible packages."""
+
+    _merge_hash = None
+    _from_yaml = None
+    _AnsibleDumper = None
+    _InventoryCLI = None
+    _InventoryReader = None
+    _CustomInventoryCLI = None
+
+    @classmethod
+    def get_merge_hash(cls):
+        """Get the merge_hash function from ansible.utils.vars."""
+        if cls._merge_hash is None:
+            from ansible.utils.vars import merge_hash
+
+            cls._merge_hash = merge_hash
+        return cls._merge_hash
+
+    @classmethod
+    def get_from_yaml(cls):
+        """Get the from_yaml function from ansible.utils.vars."""
+        if cls._from_yaml is None:
+            from ansible.parsing.utils.yaml import from_yaml
+
+            cls._from_yaml = from_yaml
+        return cls._from_yaml
+
+    @classmethod
+    def get_AnsibleDumper(cls):
+        """Get the AnsibleDumper class from ansible.utils.vars."""
+        if cls._AnsibleDumper is None:
+            from ansible.parsing.yaml.dumper import AnsibleDumper
+
+            cls._AnsibleDumper = AnsibleDumper
+        return cls._AnsibleDumper
+
+    @classmethod
+    def get_InventoryCLI(cls):
+        """Get the InventoryCLI class from ansible.cli.inventory."""
+        if cls._InventoryCLI is None:
+            from ansible.cli.inventory import InventoryCLI
+
+            cls._InventoryCLI = InventoryCLI
+        return cls._InventoryCLI
+
+    @classmethod
+    def get_CustomInventoryCLI(cls):
+        """Get the CustomInventoryCLI class."""
+
+        class _CustomInventoryCLI(cls.get_InventoryCLI()):
+            """Represent a custom Ansible inventory CLI which does nothing.
+            This is used to load inventory files with Ansible code.
+            """
+
+            def __init__(self):
+                super().__init__(["program", "--list"])
+                # "run" must be called from CLI (the parent of InventoryCLI), to
+                # initialize context (reading ansible.cfg for example).
+                super(cls.get_InventoryCLI(), self).run()
+                # Get InventoryManager instance
+                _, self.inventory, _ = self._play_prereqs()
+
+            # Avoid call InventoryCLI "run", we do not need to run InventoryCLI
+            def run(self):
+                pass
+
+        if cls._CustomInventoryCLI is None:
+            cls._CustomInventoryCLI = _CustomInventoryCLI()
+        return cls._CustomInventoryCLI

--- a/tdp/core/inventory_reader.py
+++ b/tdp/core/inventory_reader.py
@@ -1,45 +1,28 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, TextIO
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, TextIO
 
 import yaml
-from ansible.cli.inventory import InventoryCLI
-from ansible.inventory.manager import InventoryManager
+
+from tdp.core.ansible_loader import AnsibleLoader
 
 try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader
 
-
-# From ansible/cli/inventory.py
-class _CustomInventoryCLI(InventoryCLI):
-    """Represent a custom Ansible inventory CLI which does nothing.
-    This is used to load inventory files with Ansible code.
-    """
-
-    def __init__(self):
-        super().__init__(["program", "--list"])
-        # "run" must be called from CLI (the parent of InventoryCLI), to
-        # initialize context (reading ansible.cfg for example).
-        super(InventoryCLI, self).run()
-        # Get InventoryManager instance
-        _, self.inventory, _ = self._play_prereqs()
-
-    # Avoid call InventoryCLI "run", we do not need to run InventoryCLI
-    def run(self):
-        pass
-
-
-custom_inventory_cli_instance = _CustomInventoryCLI()
+if TYPE_CHECKING:
+    from ansible.inventory.manager import InventoryManager
 
 
 class InventoryReader:
     """Represent an Ansible inventory reader."""
 
     def __init__(self, inventory: Optional[InventoryManager] = None):
-        self.inventory = inventory or custom_inventory_cli_instance.inventory
+        self.inventory = inventory or AnsibleLoader.get_CustomInventoryCLI().inventory
 
     def get_hosts(self, *args, **kwargs) -> list[str]:
         """Takes a pattern or list of patterns and returns a list of matching

--- a/tdp/core/variables/variables.py
+++ b/tdp/core/variables/variables.py
@@ -10,10 +10,8 @@ from typing import Optional
 from weakref import proxy
 
 import yaml
-from ansible.parsing.utils.yaml import from_yaml
-from ansible.parsing.yaml.dumper import AnsibleDumper
-from ansible.utils.vars import merge_hash
 
+from tdp.core.ansible_loader import AnsibleLoader
 from tdp.core.types import PathLike
 
 
@@ -94,7 +92,7 @@ class VariablesDict(MutableMapping):
         Args:
             mapping: Mapping to merge.
         """
-        self._content = merge_hash(self._content, mapping)
+        self._content = AnsibleLoader.get_merge_hash()(self._content, mapping)
 
     def __getitem__(self, key):
         return self._content.__getitem__(key)
@@ -135,7 +133,10 @@ class _VariablesIOWrapper(VariablesDict):
         self._file_path = path
         self._file_descriptor = open(self._file_path, mode or "r+")
         # Initialize the content of the variables file
-        super().__init__(content=from_yaml(self._file_descriptor) or {}, name=path.name)
+        super().__init__(
+            content=AnsibleLoader.get_from_yaml()(self._file_descriptor) or {},
+            name=path.name,
+        )
 
     def __enter__(self) -> _VariablesIOWrapper:
         return proxy(self)
@@ -156,7 +157,12 @@ class _VariablesIOWrapper(VariablesDict):
         # Write the content of the variables file on disk
         self._file_descriptor.seek(0)
         self._file_descriptor.write(
-            yaml.dump(self._content, Dumper=AnsibleDumper, sort_keys=False, width=1000)
+            yaml.dump(
+                self._content,
+                Dumper=AnsibleLoader.get_AnsibleDumper(),
+                sort_keys=False,
+                width=1000,
+            )
         )
         self._file_descriptor.truncate()
         self._file_descriptor.flush()


### PR DESCRIPTION
This pull request introduces a new `AnsibleLoader` class to centralize and lazily load Ansible-related utilities, improving code maintainability and reducing direct dependencies on Ansible modules throughout the codebase. The changes include replacing direct imports and usage of Ansible utilities with methods from the `AnsibleLoader` class, refactoring related functionality, and cleaning up redundant code.

### Refactoring for centralized Ansible utility management:
* Introduced the `AnsibleLoader` class in `tdp/core/ansible_loader.py`, which provides lazy-loading methods for Ansible utilities such as `merge_hash`, `from_yaml`, `AnsibleDumper`, and `InventoryCLI`. It also includes a custom `CustomInventoryCLI` implementation for inventory management.

### Updates to existing files to use `AnsibleLoader`:
* Replaced direct imports of Ansible utilities (`merge_hash`, `from_yaml`, and `AnsibleDumper`) in `tdp/core/variables/variables.py` with calls to corresponding `AnsibleLoader` methods. Updated methods like `merge`, `__init__`, and `_flush_on_disk` to use these methods. [[1]](diffhunk://#diff-60263f9c86f45f8ceaaabbdb576ec29dd446d11c610fa7d7e114bafd5f925280L13-R14) [[2]](diffhunk://#diff-60263f9c86f45f8ceaaabbdb576ec29dd446d11c610fa7d7e114bafd5f925280L97-R95) [[3]](diffhunk://#diff-60263f9c86f45f8ceaaabbdb576ec29dd446d11c610fa7d7e114bafd5f925280L138-R139) [[4]](diffhunk://#diff-60263f9c86f45f8ceaaabbdb576ec29dd446d11c610fa7d7e114bafd5f925280L159-R165)
* Updated `tdp/cli/commands/default_diff.py` to replace the direct usage of `merge_hash` with `AnsibleLoader.get_merge_hash()`. [[1]](diffhunk://#diff-1de68b381ba79925d0cb9a1531ee77bf2000572821fb60e8d9137b483f1cbb58L46-R46) [[2]](diffhunk://#diff-1de68b381ba79925d0cb9a1531ee77bf2000572821fb60e8d9137b483f1cbb58L83-R82)
* Refactored `tdp/core/inventory_reader.py` to replace the custom `_CustomInventoryCLI` class with the `CustomInventoryCLI` provided by `AnsibleLoader`.

### Code cleanup and simplification:
* Removed redundant imports and custom implementations of Ansible utilities and classes from `tdp/core/inventory_reader.py`, as they are now handled by `AnsibleLoader`.

These changes enhance modularity, simplify the codebase, and make it easier to manage dependencies on Ansible utilities.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
