### PR TITLE
fix: remove subgraph from topo sort

### DIFF
--- a/tdp/core/dag.py
+++ b/tdp/core/dag.py
@@ -124,11 +124,7 @@ class Dag:
                     item
                 )
 
-        # If specific items are provided, restrict the graph to those nodes.
-        # Otherwise, use the entire graph.
-        graph = self.graph.subgraph(key_items.keys()) if key_items else self.graph
-
-        # Define a priority function for nodes based on service priority.
+        # Define a priority function for nodes based on service priority
         def priority_key(node: str) -> str:
             operation = self.operations[OperationName.from_str(node)]
             operation_priority = SERVICE_PRIORITY.get(
@@ -136,14 +132,16 @@ class Dag:
             )
             return f"{operation_priority:02d}_{node}"
 
-        topo_sorted = nx.lexicographical_topological_sort(graph, priority_key)
+        topo_sorted = nx.lexicographical_topological_sort(self.graph, priority_key)
+
         # Yield the sorted items. If custom items are provided, map the sorted nodes
         # back to the original items.
         if key_items:
             for node in topo_sorted:
-                for item in key_items[node]:
-                    yield item
-        return topo_sorted
+                if node in key_items:
+                    yield from key_items[node]
+        else:
+            return topo_sorted
 
     def topological_sort(
         self,


### PR DESCRIPTION
Fix the `topological_sort_key` method from the `Dag` class. The method should not use a subgraph as it removes not direct edges, which create invalid sorting.

Note: Computing a subgraph may be possible by applying [`transitive_closure`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.dag.transitive_closure.html) to the graph before creating the subgraph.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
