### PR TITLE
feat(deployment_model): added the option to plan a dag with components from only one host

### DIFF
--- a/tdp/cli/commands/plan/dag.py
+++ b/tdp/cli/commands/plan/dag.py
@@ -11,6 +11,7 @@ from tdp.cli.params import (
     collections_option,
     database_dsn_option,
     force_option,
+    hosts_option,
     preview_option,
     rolling_interval_option,
 )
@@ -59,12 +60,7 @@ if TYPE_CHECKING:
     is_flag=True,
     help="Replace 'start' operations by 'stop' operations. This option should be used with `--reverse`.",
 )
-@click.option(
-    "--host",
-    envvar="host",
-    type=str,
-    help="Plan the dag with operations from one single host machine."
-)
+@hosts_option(help="Hosts where operations are launched. Can be used multiple times.")
 @rolling_interval_option
 @preview_option
 @force_option
@@ -83,7 +79,7 @@ def dag(
     filter: Optional[str] = None,
     is_regex: bool = False,
     rolling_interval: Optional[int] = None,
-    host: Optional[str] = None,
+    hosts: Optional[tuple[str]] = None,
 ):
     """Deploy from the DAG."""
 
@@ -132,7 +128,7 @@ def dag(
         reverse=reverse,
         stop=stop,
         rolling_interval=rolling_interval,
-        host_name=host
+        host_names=hosts
     )
     if preview:
         print_deployment(deployment)


### PR DESCRIPTION
… chosen host

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #676

#### Additional comments

This PR adds a `--host` option in the `deploy` cli to limit the deployment to that host. Therefore the `DeploymentRunner` takes that host into account if it is mentioned in the cli command.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
