### PR TITLE
refactor(scripts): move the spark3 service playbook before yarn in al…

### DIFF
--- a/scripts/playbooks.py
+++ b/scripts/playbooks.py
@@ -115,6 +115,8 @@ def playbooks(
 
     playbooks_prefix = "../"
     with Path(meta_dir, "all_per_service.yml").open("w") as all_per_service_fd:
+        services = list(services)
+        services.insert(services.index("yarn"), services.pop(services.index("spark3")))
         write_copyright_licence_headers(all_per_service_fd)
         all_per_service_fd.write("---\n")
         for service in services:


### PR DESCRIPTION
…l_per_service.yml

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes None

#### Additional comments

If TDP is deployed with the `all_per_service.yml`, `spark3` must be deployed before `yarn` because the `spark_shuffle.class` set in Yarn must be able to link to a jar file in the spark3 release.



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
