### PR TITLE
`CollectionReader` should not instanciate an `InventoryReader`

### DIFF
--- a/tdp/core/collections/collection_reader.py
+++ b/tdp/core/collections/collection_reader.py
@@ -92,7 +92,7 @@ class CollectionReader:
     def __init__(
         self,
         path: PathLike,
-        inventory_reader: Optional[InventoryReader] = None,
+        inventory_reader: InventoryReader,
     ):
         """Initialize a collection.
 
@@ -106,13 +106,13 @@ class CollectionReader:
         """
         self._path = Path(path)
         self._check_collection_structure(self._path)
-        self._inventory_reader = inventory_reader or InventoryReader()
+        self._inventory_reader = inventory_reader
 
     # ? Is this method really useful?
     @staticmethod
     def from_path(
         path: PathLike,
-        inventory_reader: Optional[InventoryReader] = None,
+        inventory_reader: InventoryReader,
     ) -> CollectionReader:
         """Factory method to create a collection from a path.
 
@@ -121,7 +121,6 @@ class CollectionReader:
 
         Returns: A collection.
         """
-        inventory_reader = inventory_reader or InventoryReader()
         return CollectionReader(Path(path).expanduser().resolve(), inventory_reader)
 
     @property

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -1,11 +1,14 @@
 # Copyright 2022 TOSIT.IO
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import create_autospec
+
 import pytest
 
 from tdp.core.cluster_status import ClusterStatus
 from tdp.core.collections import Collections
 from tdp.core.dag import Dag
+from tdp.core.inventory_reader import InventoryReader
 from tdp.core.variables import ClusterVariables
 from tests.conftest import generate_collection_at_path
 
@@ -74,6 +77,11 @@ def mock_cluster_variables(
     return ClusterVariables.initialize_cluster_variables(
         collections=mock_collections, tdp_vars=tmp_path_factory.mktemp("tdp_vars")
     )
+
+
+@pytest.fixture
+def mock_inventory_reader() -> InventoryReader:
+    return create_autospec(InventoryReader, instance=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
`InventoryReader` should only be instantiated in `Collections` and then passed to `CollectionReader`.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
