### PR TITLE
Deployment model state should never be None

### DIFF
--- a/tdp/core/models/deployment_model.py
+++ b/tdp/core/models/deployment_model.py
@@ -92,9 +92,7 @@ class DeploymentModel(BaseModel):
     )
     start_time: Mapped[Optional[datetime]] = mapped_column(doc="Deployment start time.")
     end_time: Mapped[Optional[datetime]] = mapped_column(doc="Deployment end time.")
-    state: Mapped[Optional[DeploymentStateEnum]] = mapped_column(
-        doc="Deployment state."
-    )
+    state: Mapped[DeploymentStateEnum] = mapped_column(doc="Deployment state.")
     deployment_type: Mapped[Optional[DeploymentTypeEnum]] = mapped_column(
         doc="Deployment type."
     )

--- a/tests/unit/core/models/test_deployment_log.py
+++ b/tests/unit/core/models/test_deployment_log.py
@@ -342,7 +342,9 @@ class Test_multiple_db:
 
         with create_session(db_engine) as session:
             # All databases except SQLite have a constraint on foreignkey deployment_id.
-            deployment_content = DeploymentModel(id=1)
+            deployment_content = DeploymentModel(
+                id=1, state=DeploymentStateEnum.PLANNED
+            )
             session.add(deployment_content)
             # Add the lorem ipsum text in bytes to the logs column in the operation table.
             operation_content = OperationModel(


### PR DESCRIPTION
This pull request makes a small but important change to the `DeploymentModel` in `tdp/core/models/deployment_model.py`. The type of the `state` field is updated to require a value, ensuring that every deployment has a defined state.

- Model improvement:
  * Made the `state` field in `DeploymentModel` non-optional by removing `Optional`, so a deployment must always have a state.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
