### PR TITLE
Remove psycopg2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ pip install "tdp-lib[visualization]@https://github.com/TOSIT-IO/tdp-lib/tarball/
 tdp init
 ```
 
+### Supported databases
+
+`tdp-lib` uses [SQLite](https://sqlite.org/) by default. Other backends are supported:
+
+- [PostgreSQL](https://www.postgresql.org/) - install with `pip install tdp-lib[postgresql]`
+- [MySQL](https://www.mysql.com)/[MariaDB](https://mariadb.org/) - install with `pip install tdp-lib[mysql]`
+
 ## CLI Usage
 
 > [!NOTE]
@@ -71,7 +78,7 @@ Contributions are welcome! Here are some guidelines specific to this project:
     # Install Poetry
     curl -sSL https://install.python-poetry.org | python3 -
     # Install the dependencies
-    poetry install -E postgresql-binary -E mysql
+    poetry install --all-extras
     ```
 
 - Commit messages must adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.

--- a/poetry.lock
+++ b/poetry.lock
@@ -920,7 +920,6 @@ description = "psycopg2 - Python-PostgreSQL Database Adapter"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"postgresql\""
 files = [
     {file = "psycopg2-2.9.11-cp310-cp310-win_amd64.whl", hash = "sha256:103e857f46bb76908768ead4e2d0ba1d1a130e7b8ed77d3ae91e8b33481813e8"},
     {file = "psycopg2-2.9.11-cp311-cp311-win_amd64.whl", hash = "sha256:210daed32e18f35e3140a1ebe059ac29209dd96468f2f7559aa59f75ee82a5cb"},
@@ -938,7 +937,7 @@ description = "psycopg2 - Python-PostgreSQL Database Adapter"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"postgresql-binary\""
+markers = "extra == \"postgresql\""
 files = [
     {file = "psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c"},
     {file = "psycopg2_binary-2.9.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d6fe6b47d0b42ce1c9f1fa3e35bb365011ca22e39db37074458f27921dca40f2"},
@@ -1608,11 +1607,10 @@ markers = {dev = "python_version < \"3.13\""}
 
 [extras]
 mysql = ["pymysql"]
-postgresql = ["psycopg2"]
-postgresql-binary = ["psycopg2-binary"]
+postgresql = ["psycopg2-binary"]
 visualization = ["matplotlib", "numpy", "pydot"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.0,!=3.9.7,<4.0"
-content-hash = "c1c76eab93332ff9f923d960406aaa31eda50487bf77a4104eed45470b001faa"
+content-hash = "49eca8a5e645ddec86760276070a483dff88b66b21739d19525fa8f37355c3b2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,7 @@ python-lorem = "^1.3.0.post1"
 
 [tool.poetry.extras]
 visualization = ["matplotlib", "pydot", "numpy"]
-postgresql = ["psycopg2"]
-postgresql-binary = ["psycopg2-binary"]
+postgresql = ["psycopg2-binary"]
 mysql = ["pymysql"]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

Drop support for the `psycopg2` dependency (build from sources):

- It requires some extra system dependencies that may be missing.
- It blocked the use of the `--all-extras` option as it does not make sense to install both `postgresql` and `postgresql-binary` at the same time.

`postgresql` extra dependencies has been updated to contain `psycopg2-binary` and `postgresql-binary` extra dependencies has been deleted. 

This PR also adds some information about extra supported backend in the README.

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
